### PR TITLE
chore: run integration tests on push to develop

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,4 +21,4 @@ jobs:
   test-integration:
     uses: wspulse/.github/.github/workflows/go-integration.yml@main
     needs: [check]
-    if: github.ref == 'refs/heads/main' || (github.event_name == 'pull_request' && (github.base_ref == 'main' || github.base_ref == 'develop'))
+    if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop' || (github.event_name == 'pull_request' && (github.base_ref == 'main' || github.base_ref == 'develop'))


### PR DESCRIPTION
Add refs/heads/develop to test-integration if condition — integration tests now run on all four triggers.