### PR TITLE
feat: remove Frame.ID field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,9 @@
 
 - `WithSendBufferSize(n int)` option — configurable outbound channel capacity [1, 4096], default 256
 
-### Changed
+### Removed
 
-- `Frame.ID` field removed — transport layer does not use it. Applications needing message IDs should use Payload.
+- **BREAKING**: `Frame.ID` field removed — transport layer does not use it. Applications needing message IDs should use Payload.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,6 @@ Every frame sent or received is a JSON object on the wire:
 
 ```json
 {
-  "id": "msg-001",
   "event": "chat.message",
   "payload": { "text": "hello" }
 }


### PR DESCRIPTION
## Summary

Update CHANGELOG for Frame.ID removal. No code changes — client-go already only uses Frame.Event and Frame.Payload.

## Changes

- CHANGELOG: add Frame.ID removal entry under [Unreleased]

## Checklist

### Required

- [x] `make check` passes (`fmt` → `lint` → `test`)
- [x] Each commit represents exactly one logical change
- [x] No unrelated code reformatting in this PR