### PR TITLE
test: adopt testify for test assertions

### DIFF
--- a/backoff_test.go
+++ b/backoff_test.go
@@ -3,6 +3,9 @@ package client
 import (
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestBackoff_DoublesEachAttempt(t *testing.T) {
@@ -13,9 +16,8 @@ func TestBackoff_DoublesEachAttempt(t *testing.T) {
 		fullDelay := base * time.Duration(1<<uint(i))
 		half := fullDelay / 2
 		got := backoff(i, base, max)
-		if got < half || got > fullDelay {
-			t.Fatalf("attempt %d: want [%v, %v], got %v", i, half, fullDelay, got)
-		}
+		require.GreaterOrEqual(t, got, half, "attempt %d: got %v, want >= %v", i, got, half)
+		require.LessOrEqual(t, got, fullDelay, "attempt %d: got %v, want <= %v", i, got, fullDelay)
 	}
 }
 
@@ -25,9 +27,8 @@ func TestBackoff_CappedAtMax(t *testing.T) {
 	max := 5 * time.Second
 	half := max / 2
 	got := backoff(10, base, max)
-	if got < half || got > max {
-		t.Fatalf("want [%v, %v], got %v", half, max, got)
-	}
+	require.GreaterOrEqual(t, got, half, "got %v, want >= %v", got, half)
+	require.LessOrEqual(t, got, max, "got %v, want <= %v", got, max)
 }
 
 func TestBackoff_AttemptAbove62_CapsAtMaxShift(t *testing.T) {
@@ -35,13 +36,11 @@ func TestBackoff_AttemptAbove62_CapsAtMaxShift(t *testing.T) {
 	max := 30 * time.Second
 	half := max / 2
 	got := backoff(63, base, max)
-	if got < half || got > max {
-		t.Fatalf("attempt=63: want [%v, %v], got %v", half, max, got)
-	}
+	require.GreaterOrEqual(t, got, half, "attempt=63: got %v, want >= %v", got, half)
+	require.LessOrEqual(t, got, max, "attempt=63: got %v, want <= %v", got, max)
 	got100 := backoff(100, base, max)
-	if got100 < half || got100 > max {
-		t.Fatalf("attempt=100: want [%v, %v], got %v", half, max, got100)
-	}
+	require.GreaterOrEqual(t, got100, half, "attempt=100: got %v, want >= %v", got100, half)
+	require.LessOrEqual(t, got100, max, "attempt=100: got %v, want <= %v", got100, max)
 }
 
 func TestBackoff_OverflowToNegative_CapsAtMax(t *testing.T) {
@@ -50,9 +49,8 @@ func TestBackoff_OverflowToNegative_CapsAtMax(t *testing.T) {
 	max := 30 * time.Second
 	half := max / 2
 	got := backoff(62, base, max)
-	if got < half || got > max {
-		t.Fatalf("overflow case: want [%v, %v], got %v", half, max, got)
-	}
+	require.GreaterOrEqual(t, got, half, "overflow case: got %v, want >= %v", got, half)
+	require.LessOrEqual(t, got, max, "overflow case: got %v, want <= %v", got, max)
 }
 
 func TestBackoff_ZeroAttempt_ReturnsBase(t *testing.T) {
@@ -61,9 +59,8 @@ func TestBackoff_ZeroAttempt_ReturnsBase(t *testing.T) {
 	max := 30 * time.Second
 	half := base / 2
 	got := backoff(0, base, max)
-	if got < half || got > base {
-		t.Fatalf("attempt=0: want [%v, %v], got %v", half, base, got)
-	}
+	require.GreaterOrEqual(t, got, half, "attempt=0: got %v, want >= %v", got, half)
+	require.LessOrEqual(t, got, base, "attempt=0: got %v, want <= %v", got, base)
 }
 
 func TestBackoff_HasJitter(t *testing.T) {
@@ -77,9 +74,7 @@ func TestBackoff_HasJitter(t *testing.T) {
 		d := backoff(attempt, base, max)
 		seen[d] = true
 	}
-	if len(seen) < 2 {
-		t.Fatalf("backoff returned identical value %d times — no jitter", 100)
-	}
+	assert.GreaterOrEqual(t, len(seen), 2, "backoff returned identical value 100 times — no jitter")
 }
 
 func TestBackoff_JitterWithinRange(t *testing.T) {
@@ -92,8 +87,7 @@ func TestBackoff_JitterWithinRange(t *testing.T) {
 
 	for i := 0; i < 200; i++ {
 		d := backoff(attempt, base, max)
-		if d < half || d > fullDelay {
-			t.Fatalf("attempt %d: want d in [%v, %v], got %v", attempt, half, fullDelay, d)
-		}
+		require.GreaterOrEqual(t, d, half, "attempt %d, iter %d: got %v, want >= %v", attempt, i, d, half)
+		require.LessOrEqual(t, d, fullDelay, "attempt %d, iter %d: got %v, want <= %v", attempt, i, d, fullDelay)
 	}
 }

--- a/basic_test.go
+++ b/basic_test.go
@@ -2,9 +2,11 @@ package client_test
 
 import (
 	"encoding/json"
-	"errors"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	wspulse "github.com/wspulse/core"
 
@@ -25,15 +27,11 @@ func TestSendAndReceive(t *testing.T) {
 	go echoLoop(mt, echoDone)
 
 	frame := wspulse.Frame{Event: "echo", Payload: []byte(`"hello"`)}
-	if err := c.Send(frame); err != nil {
-		t.Fatalf("Send failed: %v", err)
-	}
+	require.NoError(t, c.Send(frame), "Send failed")
 
 	select {
 	case f := <-received:
-		if f.Event != "echo" {
-			t.Errorf("Event: want %q, got %q", "echo", f.Event)
-		}
+		assert.Equal(t, "echo", f.Event)
 	case <-time.After(time.Second):
 		t.Fatal("timed out waiting for echo")
 	}
@@ -51,9 +49,7 @@ func TestSend_AfterClose_ReturnsErrConnectionClosed(t *testing.T) {
 	c, _, _ := dialWithMock(t)
 	_ = c.Close()
 	sendErr := c.Send(wspulse.Frame{Event: "msg"})
-	if !errors.Is(sendErr, wspulse.ErrConnectionClosed) {
-		t.Errorf("want ErrConnectionClosed, got %v", sendErr)
-	}
+	assert.ErrorIs(t, sendErr, wspulse.ErrConnectionClosed)
 }
 
 func TestDone_ClosedAfterClose(t *testing.T) {
@@ -73,29 +69,19 @@ func TestSend_WritesCorrectData(t *testing.T) {
 	t.Cleanup(func() { _ = c.Close() })
 
 	frame := wspulse.Frame{Event: "test", Payload: []byte(`"data"`)}
-	if err := c.Send(frame); err != nil {
-		t.Fatalf("Send failed: %v", err)
-	}
+	require.NoError(t, c.Send(frame), "Send failed")
 
 	w, ok := mt.WaitWrite(time.Second)
-	if !ok {
-		t.Fatal("timed out waiting for write")
-	}
-	if w.messageType != 1 { // TextMessage (JSONCodec)
-		t.Errorf("messageType: want 1, got %d", w.messageType)
-	}
+	require.True(t, ok, "timed out waiting for write")
+	assert.Equal(t, 1, w.messageType, "messageType") // TextMessage (JSONCodec)
 
 	// Decode the written data and verify.
 	var wireFrame struct {
 		Event   string          `json:"event"`
 		Payload json.RawMessage `json:"payload"`
 	}
-	if err := json.Unmarshal(w.data, &wireFrame); err != nil {
-		t.Fatalf("unmarshal written data: %v", err)
-	}
-	if wireFrame.Event != "test" {
-		t.Errorf("event: want %q, got %q", "test", wireFrame.Event)
-	}
+	require.NoError(t, json.Unmarshal(w.data, &wireFrame), "unmarshal written data")
+	assert.Equal(t, "test", wireFrame.Event)
 }
 
 func TestNormalCloseFrame(t *testing.T) {
@@ -116,7 +102,5 @@ func TestNormalCloseFrame(t *testing.T) {
 			break
 		}
 	}
-	if !foundClose {
-		t.Error("Close() did not produce a WebSocket close frame (messageType=8)")
-	}
+	assert.True(t, foundClose, "Close() did not produce a WebSocket close frame (messageType=8)")
 }

--- a/callback_test.go
+++ b/callback_test.go
@@ -8,6 +8,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	wspulse "github.com/wspulse/core"
 
 	"github.com/wspulse/client-go"
@@ -44,9 +47,7 @@ func TestOnDisconnect_NilOnNormalClose(t *testing.T) {
 
 	select {
 	case got := <-disconnectErr:
-		if got != nil {
-			t.Errorf("want nil error on normal Close(), got %v", got)
-		}
+		assert.NoError(t, got, "want nil error on normal Close()")
 	case <-time.After(time.Second):
 		t.Fatal("timed out waiting for onDisconnect")
 	}
@@ -67,9 +68,7 @@ func TestOnDisconnect_NonNilOnServerDrop(t *testing.T) {
 
 	select {
 	case got := <-disconnectErr:
-		if got == nil {
-			t.Error("want non-nil error on server drop, got nil")
-		}
+		assert.Error(t, got, "want non-nil error on server drop")
 	case <-time.After(time.Second):
 		t.Fatal("timed out waiting for onDisconnect")
 	}
@@ -90,9 +89,7 @@ func TestOnDisconnect_IsErrConnectionLostOnServerDrop(t *testing.T) {
 
 	select {
 	case got := <-disconnectErr:
-		if !errors.Is(got, client.ErrConnectionLost) {
-			t.Errorf("want errors.Is(err, ErrConnectionLost), got %v", got)
-		}
+		assert.ErrorIs(t, got, client.ErrConnectionLost)
 	case <-time.After(time.Second):
 		t.Fatal("timed out waiting for onDisconnect")
 	}
@@ -117,9 +114,7 @@ func TestOnDisconnect_NonNilOnMaxRetries(t *testing.T) {
 			disconnectErr <- err
 		}),
 	)
-	if err != nil {
-		t.Fatalf("Dial failed: %v", err)
-	}
+	require.NoError(t, err, "Dial failed")
 	t.Cleanup(func() { _ = c.Close() })
 
 	// Kill the first transport.
@@ -131,9 +126,7 @@ func TestOnDisconnect_NonNilOnMaxRetries(t *testing.T) {
 
 	select {
 	case got := <-disconnectErr:
-		if got == nil {
-			t.Error("want non-nil error on max retries exhausted, got nil")
-		}
+		assert.Error(t, got, "want non-nil error on max retries exhausted")
 	case <-time.After(3 * time.Second):
 		t.Fatal("timed out waiting for onDisconnect")
 	}
@@ -164,9 +157,7 @@ func TestClose_OnDisconnectFiresExactlyOnce(t *testing.T) {
 			}
 		}),
 	)
-	if err != nil {
-		t.Fatalf("Dial failed: %v", err)
-	}
+	require.NoError(t, err, "Dial failed")
 
 	// Start echo loop.
 	echoDone := make(chan struct{})
@@ -174,9 +165,7 @@ func TestClose_OnDisconnectFiresExactlyOnce(t *testing.T) {
 	go echoLoop(mt, echoDone)
 
 	// Confirm connection is established by round-tripping a frame.
-	if err := c.Send(wspulse.Frame{Event: "ping", Payload: []byte(`"1"`)}); err != nil {
-		t.Fatalf("Send failed: %v", err)
-	}
+	require.NoError(t, c.Send(wspulse.Frame{Event: "ping", Payload: []byte(`"1"`)}), "Send failed")
 	select {
 	case <-received:
 	case <-time.After(time.Second):
@@ -189,9 +178,7 @@ func TestClose_OnDisconnectFiresExactlyOnce(t *testing.T) {
 	dc := disconnectCount
 	mu.Unlock()
 
-	if dc != 1 {
-		t.Errorf("onDisconnect fired %d times, want exactly 1", dc)
-	}
+	assert.Equal(t, 1, dc, "onDisconnect fired count")
 }
 
 func TestOnTransportDrop_FiresOnReconnect(t *testing.T) {
@@ -216,9 +203,7 @@ func TestOnTransportDrop_FiresOnReconnect(t *testing.T) {
 			}
 		}),
 	)
-	if err != nil {
-		t.Fatalf("Dial failed: %v", err)
-	}
+	require.NoError(t, err, "Dial failed")
 	t.Cleanup(func() { _ = c.Close() })
 
 	// Kill the first transport.
@@ -267,9 +252,7 @@ func TestOnTransportRestore_FiresAfterReconnect(t *testing.T) {
 			}
 		}),
 	)
-	if err != nil {
-		t.Fatalf("Dial failed: %v", err)
-	}
+	require.NoError(t, err, "Dial failed")
 	t.Cleanup(func() { _ = c.Close() })
 
 	// Kill the first transport.
@@ -287,9 +270,7 @@ func TestOnTransportRestore_FiresAfterReconnect(t *testing.T) {
 	for fc.TimerCount() == 0 && time.Now().Before(deadline) {
 		time.Sleep(time.Millisecond)
 	}
-	if fc.TimerCount() == 0 {
-		t.Fatal("no backoff timer created")
-	}
+	require.Greater(t, fc.TimerCount(), 0, "no backoff timer created")
 	fc.mu.Lock()
 	fc.timers[len(fc.timers)-1].timer.Reset(0)
 	fc.mu.Unlock()
@@ -307,14 +288,10 @@ func TestOnTransportRestore_FiresAfterReconnect(t *testing.T) {
 	go echoLoop(mt2, echoDone)
 
 	// Verify message delivery works after restore.
-	if err := c.Send(wspulse.Frame{Event: "post-restore", Payload: []byte(`"ok"`)}); err != nil {
-		t.Fatalf("Send after restore: %v", err)
-	}
+	require.NoError(t, c.Send(wspulse.Frame{Event: "post-restore", Payload: []byte(`"ok"`)}), "Send after restore")
 	select {
 	case f := <-received:
-		if f.Event != "post-restore" {
-			t.Fatalf("want event %q, got %q", "post-restore", f.Event)
-		}
+		assert.Equal(t, "post-restore", f.Event)
 	case <-time.After(time.Second):
 		t.Fatal("timed out waiting for echo after restore")
 	}
@@ -344,18 +321,14 @@ func TestOnTransportRestore_DoesNotFireOnInitialConnect(t *testing.T) {
 	go echoLoop(mt, echoDone)
 
 	// Round-trip a frame to prove all pumps are fully operational.
-	if err := c.Send(wspulse.Frame{Event: "probe"}); err != nil {
-		t.Fatalf("Send failed: %v", err)
-	}
+	require.NoError(t, c.Send(wspulse.Frame{Event: "probe"}), "Send failed")
 	select {
 	case <-received:
 	case <-time.After(time.Second):
 		t.Fatal("timed out waiting for probe echo")
 	}
 
-	if count := restoreCount.Load(); count != 0 {
-		t.Errorf("onTransportRestore fired %d times on initial connect, want 0", count)
-	}
+	assert.Equal(t, int32(0), restoreCount.Load(), "onTransportRestore should not fire on initial connect")
 }
 
 func TestOnTransportRestore_NotFiredOnFailedReconnect(t *testing.T) {
@@ -382,9 +355,7 @@ func TestOnTransportRestore_NotFiredOnFailedReconnect(t *testing.T) {
 			disconnectErr <- err
 		}),
 	)
-	if err != nil {
-		t.Fatalf("Dial failed: %v", err)
-	}
+	require.NoError(t, err, "Dial failed")
 	t.Cleanup(func() { _ = c.Close() })
 
 	// Kill the first transport.
@@ -397,14 +368,10 @@ func TestOnTransportRestore_NotFiredOnFailedReconnect(t *testing.T) {
 	// Wait for onDisconnect with ErrRetriesExhausted.
 	select {
 	case got := <-disconnectErr:
-		if !errors.Is(got, client.ErrRetriesExhausted) {
-			t.Errorf("want ErrRetriesExhausted, got %v", got)
-		}
+		assert.ErrorIs(t, got, client.ErrRetriesExhausted)
 	case <-time.After(3 * time.Second):
 		t.Fatal("timed out waiting for onDisconnect")
 	}
 
-	if count := restoreCount.Load(); count != 0 {
-		t.Errorf("onTransportRestore fired %d times, want 0", count)
-	}
+	assert.Equal(t, int32(0), restoreCount.Load(), "onTransportRestore should not fire on failed reconnect")
 }

--- a/client_test.go
+++ b/client_test.go
@@ -6,6 +6,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/wspulse/client-go"
 	wspulse "github.com/wspulse/core"
 )
@@ -33,9 +36,7 @@ func TestNormalizeScheme(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			got := client.NormalizeScheme(tc.input)
-			if got != tc.want {
-				t.Errorf("NormalizeScheme(%q) = %q, want %q", tc.input, got, tc.want)
-			}
+			assert.Equal(t, tc.want, got, "NormalizeScheme(%q)", tc.input)
 		})
 	}
 }
@@ -43,38 +44,24 @@ func TestNormalizeScheme(t *testing.T) {
 func TestDial_ReturnsErrorOnBadURL(t *testing.T) {
 	t.Parallel()
 	_, err := client.Dial("ws://localhost:0/no-such-server")
-	if err == nil {
-		t.Error("expected error dialing unreachable server, got nil")
-	}
+	assert.Error(t, err, "expected error dialing unreachable server")
 }
 
 func TestDial_ErrorFormat(t *testing.T) {
 	t.Parallel()
 	_, err := client.Dial("ws://localhost:0/no-such-server")
-	if err == nil {
-		t.Fatal("expected error dialing unreachable server, got nil")
-	}
+	require.Error(t, err, "expected error dialing unreachable server")
 	const wantPrefix = "wspulse: dial: "
-	if !strings.HasPrefix(err.Error(), wantPrefix) {
-		t.Errorf("error format: want prefix %q, got %q", wantPrefix, err.Error())
-	}
-	if errors.Unwrap(err) == nil {
-		t.Error("Dial error must wrap the underlying dial error")
-	}
+	assert.True(t, strings.HasPrefix(err.Error(), wantPrefix),
+		"error format: want prefix %q, got %q", wantPrefix, err.Error())
+	assert.NotNil(t, errors.Unwrap(err), "Dial error must wrap the underlying dial error")
 }
 
 func TestClient_WithCodec_Nil_Panics(t *testing.T) {
 	t.Parallel()
-	defer func() {
-		r := recover()
-		if r == nil {
-			t.Fatal("expected panic on nil codec, got none")
-		}
-		if msg, ok := r.(string); !ok || msg != "wspulse: codec must not be nil" {
-			t.Fatalf("unexpected panic message: %v", r)
-		}
-	}()
-	_ = client.WithCodec(nil)
+	require.PanicsWithValue(t, "wspulse: codec must not be nil", func() {
+		_ = client.WithCodec(nil)
+	})
 }
 
 func TestClient_WithHeartbeat_InvalidParams_Panics(t *testing.T) {
@@ -95,16 +82,9 @@ func TestClient_WithHeartbeat_InvalidParams_Panics(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			defer func() {
-				r := recover()
-				if r == nil {
-					t.Fatal("expected panic")
-				}
-				if msg, ok := r.(string); !ok || msg != tc.wantMsg {
-					t.Fatalf("panic message = %v, want %q", r, tc.wantMsg)
-				}
-			}()
-			_ = client.WithHeartbeat(tc.ping, tc.pong, tc.writeW)
+			require.PanicsWithValue(t, tc.wantMsg, func() {
+				_ = client.WithHeartbeat(tc.ping, tc.pong, tc.writeW)
+			})
 		})
 	}
 }
@@ -122,16 +102,9 @@ func TestClient_WithSendBufferSize_InvalidParam_Panics(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			defer func() {
-				r := recover()
-				if r == nil {
-					t.Fatal("expected panic")
-				}
-				if msg, ok := r.(string); !ok || msg != tc.wantMsg {
-					t.Fatalf("panic message = %v, want %q", r, tc.wantMsg)
-				}
-			}()
-			client.WithSendBufferSize(tc.n)
+			require.PanicsWithValue(t, tc.wantMsg, func() {
+				client.WithSendBufferSize(tc.n)
+			})
 		})
 	}
 }
@@ -156,32 +129,18 @@ func TestClient_WithMaxMessageSize_InvalidParam_Panics(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			defer func() {
-				r := recover()
-				if r == nil {
-					t.Fatal("expected panic")
-				}
-				if msg, ok := r.(string); !ok || msg != tc.wantMsg {
-					t.Fatalf("panic message = %v, want %q", r, tc.wantMsg)
-				}
-			}()
-			client.WithMaxMessageSize(tc.n)
+			require.PanicsWithValue(t, tc.wantMsg, func() {
+				client.WithMaxMessageSize(tc.n)
+			})
 		})
 	}
 }
 
 func TestClient_WithLogger_Nil_Panics(t *testing.T) {
 	t.Parallel()
-	defer func() {
-		r := recover()
-		if r == nil {
-			t.Fatal("expected panic for WithLogger(nil)")
-		}
-		if msg, ok := r.(string); !ok || msg != "wspulse: logger must not be nil" {
-			t.Fatalf("unexpected panic message: %v", r)
-		}
-	}()
-	client.WithLogger(nil)
+	require.PanicsWithValue(t, "wspulse: logger must not be nil", func() {
+		client.WithLogger(nil)
+	})
 }
 
 func TestClient_WithAutoReconnect_InvalidParams_Panics(t *testing.T) {
@@ -202,16 +161,9 @@ func TestClient_WithAutoReconnect_InvalidParams_Panics(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			defer func() {
-				r := recover()
-				if r == nil {
-					t.Fatal("expected panic")
-				}
-				if msg, ok := r.(string); !ok || msg != tc.wantMsg {
-					t.Fatalf("panic message = %v, want %q", r, tc.wantMsg)
-				}
-			}()
-			_ = client.WithAutoReconnect(tc.maxRetries, tc.base, tc.max)
+			require.PanicsWithValue(t, tc.wantMsg, func() {
+				_ = client.WithAutoReconnect(tc.maxRetries, tc.base, tc.max)
+			})
 		})
 	}
 }
@@ -230,9 +182,7 @@ func TestClient_WithAutoReconnect_ValidParams_NoPanic(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			opt := client.WithAutoReconnect(tc.maxRetries, tc.base, tc.max)
-			if opt == nil {
-				t.Fatal("expected non-nil option")
-			}
+			require.NotNil(t, opt)
 		})
 	}
 }
@@ -248,9 +198,7 @@ func TestClient_CallbackOptions_Valid_NoPanic(t *testing.T) {
 		client.WithOnTransportRestore(func() {}),
 	}
 	for _, opt := range opts {
-		if opt == nil {
-			t.Error("option function returned nil")
-		}
+		assert.NotNil(t, opt, "option function returned nil")
 	}
 }
 
@@ -258,41 +206,31 @@ func TestClient_WithOnMessage_Nil_NoPanic(t *testing.T) {
 	t.Parallel()
 	// Nil callbacks should not panic at option construction time.
 	opt := client.WithOnMessage(nil)
-	if opt == nil {
-		t.Error("expected non-nil option")
-	}
+	assert.NotNil(t, opt)
 }
 
 func TestClient_WithOnTransportRestore_Nil_NoPanic(t *testing.T) {
 	t.Parallel()
 	opt := client.WithOnTransportRestore(nil)
-	if opt == nil {
-		t.Error("expected non-nil option")
-	}
+	assert.NotNil(t, opt)
 }
 
 func TestClient_WithOnDisconnect_Nil_NoPanic(t *testing.T) {
 	t.Parallel()
 	opt := client.WithOnDisconnect(nil)
-	if opt == nil {
-		t.Error("expected non-nil option")
-	}
+	assert.NotNil(t, opt)
 }
 
 func TestClient_WithOnTransportDrop_Nil_NoPanic(t *testing.T) {
 	t.Parallel()
 	opt := client.WithOnTransportDrop(nil)
-	if opt == nil {
-		t.Error("expected non-nil option")
-	}
+	assert.NotNil(t, opt)
 }
 
 func TestClient_WithDialHeaders_Nil_NoPanic(t *testing.T) {
 	t.Parallel()
 	opt := client.WithDialHeaders(nil)
-	if opt == nil {
-		t.Error("expected non-nil option")
-	}
+	assert.NotNil(t, opt)
 }
 
 func TestClient_WithMaxMessageSize_BoundaryValues(t *testing.T) {
@@ -309,9 +247,7 @@ func TestClient_WithMaxMessageSize_BoundaryValues(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			opt := client.WithMaxMessageSize(tc.n)
-			if opt == nil {
-				t.Error("expected non-nil option")
-			}
+			assert.NotNil(t, opt)
 		})
 	}
 }
@@ -329,9 +265,7 @@ func TestClient_WithHeartbeat_ValidParams_NoPanic(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			opt := client.WithHeartbeat(tc.ping, tc.pong, tc.writeW)
-			if opt == nil {
-				t.Error("expected non-nil option")
-			}
+			assert.NotNil(t, opt)
 		})
 	}
 }

--- a/lifecycle_test.go
+++ b/lifecycle_test.go
@@ -8,6 +8,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	wspulse "github.com/wspulse/core"
 
 	"github.com/wspulse/client-go"
@@ -25,9 +28,7 @@ func TestClose_WaitsForDisconnectCallback(t *testing.T) {
 		}),
 	)
 	_ = c.Close()
-	if !callbackDone.Load() {
-		t.Fatal("Close() returned before onDisconnect callback finished — orphaned callback goroutine")
-	}
+	require.True(t, callbackDone.Load(), "Close() returned before onDisconnect callback finished — orphaned callback goroutine")
 }
 
 func TestClose_WaitsForTransportDropCallback(t *testing.T) {
@@ -42,9 +43,7 @@ func TestClose_WaitsForTransportDropCallback(t *testing.T) {
 		}),
 	)
 	_ = c.Close()
-	if !callbackDone.Load() {
-		t.Fatal("Close() returned before onTransportDrop callback finished — orphaned callback goroutine")
-	}
+	require.True(t, callbackDone.Load(), "Close() returned before onTransportDrop callback finished — orphaned callback goroutine")
 }
 
 func TestClose_WaitsForDisconnectCallback_AutoReconnect(t *testing.T) {
@@ -60,9 +59,7 @@ func TestClose_WaitsForDisconnectCallback_AutoReconnect(t *testing.T) {
 		}),
 	)
 	_ = c.Close()
-	if !callbackDone.Load() {
-		t.Fatal("Close() returned before onDisconnect callback finished — orphaned callback goroutine")
-	}
+	require.True(t, callbackDone.Load(), "Close() returned before onDisconnect callback finished — orphaned callback goroutine")
 }
 
 func TestClose_WaitsForGoroutines(t *testing.T) {
@@ -81,9 +78,7 @@ func TestClose_WaitsForGoroutines(t *testing.T) {
 			client.WithDialer(md),
 			client.WithClock(fc),
 		)
-		if err != nil {
-			t.Fatalf("Dial #%d failed: %v", i, err)
-		}
+		require.NoError(t, err, "Dial #%d failed", i)
 		t.Cleanup(func() { _ = c.Close() })
 		entries[i] = entry{c: c, mt: mt}
 	}
@@ -124,9 +119,7 @@ func TestClose_WaitsForGoroutines_AutoReconnect(t *testing.T) {
 			client.WithClock(fc),
 			client.WithAutoReconnect(3, 100*time.Millisecond, 500*time.Millisecond),
 		)
-		if err != nil {
-			t.Fatalf("Dial #%d failed: %v", i, err)
-		}
+		require.NoError(t, err, "Dial #%d failed", i)
 		t.Cleanup(func() { _ = c.Close() })
 		entries[i] = entry{c: c, mt: mt}
 	}
@@ -165,9 +158,7 @@ func TestDone_FiresOnServerDrop(t *testing.T) {
 	go echoLoop(mt, echoDone)
 
 	// Confirm the connection is established by round-tripping a frame.
-	if err := c.Send(wspulse.Frame{Event: "ping", Payload: []byte(`"1"`)}); err != nil {
-		t.Fatalf("Send failed: %v", err)
-	}
+	require.NoError(t, c.Send(wspulse.Frame{Event: "ping", Payload: []byte(`"1"`)}), "Send failed")
 	select {
 	case <-received:
 	case <-time.After(time.Second):
@@ -184,9 +175,7 @@ func TestDone_FiresOnServerDrop(t *testing.T) {
 		t.Fatal("timed out: Done() did not fire after server disconnect")
 	}
 
-	if err := c.Send(wspulse.Frame{Event: "msg"}); !errors.Is(err, wspulse.ErrConnectionClosed) {
-		t.Fatalf("want ErrConnectionClosed, got %v", err)
-	}
+	assert.ErrorIs(t, c.Send(wspulse.Frame{Event: "msg"}), wspulse.ErrConnectionClosed)
 }
 
 func TestConcurrentSendAndClose_NoRace(t *testing.T) {
@@ -241,9 +230,7 @@ func TestConcurrentCloseAndTransportDrop_OnDisconnectExactlyOnce(t *testing.T) {
 			}
 		}),
 	)
-	if err != nil {
-		t.Fatalf("Dial failed: %v", err)
-	}
+	require.NoError(t, err, "Dial failed")
 	t.Cleanup(func() { _ = c.Close() })
 
 	// Start echo loop.
@@ -252,9 +239,7 @@ func TestConcurrentCloseAndTransportDrop_OnDisconnectExactlyOnce(t *testing.T) {
 	go echoLoop(mt, echoDone)
 
 	// Confirm the connection is established by round-tripping a frame.
-	if err := c.Send(wspulse.Frame{Event: "ping", Payload: []byte(`"1"`)}); err != nil {
-		t.Fatalf("Send failed: %v", err)
-	}
+	require.NoError(t, c.Send(wspulse.Frame{Event: "ping", Payload: []byte(`"1"`)}), "Send failed")
 	select {
 	case <-received:
 	case <-time.After(time.Second):
@@ -299,7 +284,5 @@ func TestConcurrentCloseAndTransportDrop_OnDisconnectExactlyOnce(t *testing.T) {
 		t.Fatal("timed out waiting for Done() after concurrent close/drop")
 	}
 
-	if count := disconnectCount.Load(); count != 1 {
-		t.Errorf("onDisconnect fired %d times, want exactly 1", count)
-	}
+	assert.Equal(t, int32(1), disconnectCount.Load(), "onDisconnect fired count")
 }

--- a/misc_test.go
+++ b/misc_test.go
@@ -8,9 +8,10 @@ import (
 	"testing"
 	"time"
 
-	"go.uber.org/zap"
-
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"go.uber.org/zap"
 
 	wspulse "github.com/wspulse/core"
 
@@ -28,9 +29,7 @@ func TestSend_BufferFull_ReturnsErrSendBufferFull(t *testing.T) {
 		client.WithClock(fc),
 		client.WithSendBufferSize(4),
 	)
-	if err != nil {
-		t.Fatalf("Dial failed: %v", err)
-	}
+	require.NoError(t, err, "Dial failed")
 	t.Cleanup(func() { _ = c.Close() })
 
 	// Block writes at the transport level so writePump stalls.
@@ -58,9 +57,7 @@ func TestSend_CustomBufferSize_Applied(t *testing.T) {
 	c, _, _ := dialWithMock(t, client.WithSendBufferSize(bufSize))
 	t.Cleanup(func() { _ = c.Close() })
 
-	if got := client.SendBufferCap(c); got != bufSize {
-		t.Errorf("SendBufferCap = %d, want %d", got, bufSize)
-	}
+	assert.Equal(t, bufSize, client.SendBufferCap(c), "SendBufferCap")
 }
 
 func TestReadPump_DecodeFailure_DropsFrame(t *testing.T) {
@@ -81,9 +78,7 @@ func TestReadPump_DecodeFailure_DropsFrame(t *testing.T) {
 
 	select {
 	case f := <-received:
-		if f.Event != "valid-frame" {
-			t.Fatalf("want event %q, got %q", "valid-frame", f.Event)
-		}
+		assert.Equal(t, "valid-frame", f.Event)
 	case <-time.After(time.Second):
 		t.Fatal("timed out waiting for valid frame")
 	}
@@ -124,15 +119,11 @@ func TestSend_EncodeError_ReturnsError(t *testing.T) {
 		client.WithClock(fc),
 		client.WithCodec(failEncodeCodecComponent{}),
 	)
-	if err != nil {
-		t.Fatalf("Dial failed: %v", err)
-	}
+	require.NoError(t, err, "Dial failed")
 	t.Cleanup(func() { _ = c.Close() })
 
 	err = c.Send(wspulse.Frame{Event: "msg"})
-	if err == nil {
-		t.Fatal("expected encode error, got nil")
-	}
+	require.Error(t, err, "expected encode error")
 }
 
 func TestHeartbeatPongTimeout_DisconnectsClient(t *testing.T) {
@@ -166,9 +157,7 @@ func TestHeartbeatPongTimeout_DisconnectsClient(t *testing.T) {
 			disconnected <- err
 		}),
 	)
-	if err != nil {
-		t.Fatalf("Dial failed: %v", err)
-	}
+	require.NoError(t, err, "Dial failed")
 	t.Cleanup(func() { _ = c.Close() })
 
 	// Wait for at least one ping write from the heartbeat ticker.
@@ -191,9 +180,7 @@ func TestHeartbeatPongTimeout_DisconnectsClient(t *testing.T) {
 
 	select {
 	case got := <-disconnected:
-		if got == nil {
-			t.Error("want non-nil error on disconnect, got nil")
-		}
+		assert.Error(t, got, "want non-nil error on disconnect")
 	case <-time.After(time.Second):
 		t.Fatal("timed out waiting for onDisconnect after simulated pong timeout")
 	}
@@ -233,18 +220,14 @@ func TestWithDialHeaders(t *testing.T) {
 		client.WithClock(fc),
 		client.WithDialHeaders(headers),
 	)
-	if err != nil {
-		t.Fatalf("Dial failed: %v", err)
-	}
+	require.NoError(t, err, "Dial failed")
 	t.Cleanup(func() { _ = c.Close() })
 
 	headerMu.Lock()
 	got := capturedHeaders.Get("X-Custom-Token")
 	headerMu.Unlock()
 
-	if got != "test-token-123" {
-		t.Errorf("header value: want %q, got %q", "test-token-123", got)
-	}
+	assert.Equal(t, "test-token-123", got, "header value")
 }
 
 func TestWithMaxMessageSize(t *testing.T) {
@@ -262,9 +245,7 @@ func TestWithMaxMessageSize(t *testing.T) {
 		client.WithClock(fc),
 		client.WithMaxMessageSize(42),
 	)
-	if err != nil {
-		t.Fatalf("Dial failed: %v", err)
-	}
+	require.NoError(t, err, "Dial failed")
 	t.Cleanup(func() { _ = c.Close() })
 
 	// Poll for readPump to call SetReadLimit.
@@ -280,9 +261,7 @@ func TestWithMaxMessageSize(t *testing.T) {
 		time.Sleep(time.Millisecond)
 	}
 
-	if readLimit != 42 {
-		t.Errorf("SetReadLimit: want 42, got %d", readLimit)
-	}
+	assert.Equal(t, int64(42), readLimit, "SetReadLimit")
 }
 
 func TestWithMaxMessageSize_OversizedMessage(t *testing.T) {
@@ -306,9 +285,7 @@ func TestWithMaxMessageSize_OversizedMessage(t *testing.T) {
 			}
 		}),
 	)
-	if err != nil {
-		t.Fatalf("Dial failed: %v", err)
-	}
+	require.NoError(t, err, "Dial failed")
 	t.Cleanup(func() { _ = c.Close() })
 
 	// Poll for readPump to call SetReadLimit.
@@ -324,9 +301,7 @@ func TestWithMaxMessageSize_OversizedMessage(t *testing.T) {
 		time.Sleep(time.Millisecond)
 	}
 
-	if readLimit != 10 {
-		t.Errorf("SetReadLimit: want 10, got %d", readLimit)
-	}
+	assert.Equal(t, int64(10), readLimit, "SetReadLimit")
 
 	// Simulate what the real gorilla transport would do: return an error
 	// when receiving an oversized message. The mock transport does not enforce
@@ -370,9 +345,7 @@ func TestWithHeartbeat_SendsPings(t *testing.T) {
 		// Use real clock so ticker fires. Short intervals for testing.
 		client.WithHeartbeat(50*time.Millisecond, 200*time.Millisecond, 5*time.Second),
 	)
-	if err != nil {
-		t.Fatalf("Dial failed: %v", err)
-	}
+	require.NoError(t, err, "Dial failed")
 	t.Cleanup(func() { _ = c.Close() })
 
 	// Wait for a ping message.
@@ -385,7 +358,5 @@ func TestWithHeartbeat_SendsPings(t *testing.T) {
 			break
 		}
 	}
-	if !pingSeen {
-		t.Fatal("no ping message received from heartbeat")
-	}
+	require.True(t, pingSeen, "no ping message received from heartbeat")
 }

--- a/reconnect_test.go
+++ b/reconnect_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	wspulse "github.com/wspulse/core"
@@ -43,9 +44,7 @@ func TestAutoReconnect_ReconnectsAndDeliversMessages(t *testing.T) {
 			}
 		}),
 	)
-	if err != nil {
-		t.Fatalf("Dial failed: %v", err)
-	}
+	require.NoError(t, err, "Dial failed")
 	t.Cleanup(func() { _ = c.Close() })
 
 	// Start echo loop on mt1.
@@ -53,14 +52,10 @@ func TestAutoReconnect_ReconnectsAndDeliversMessages(t *testing.T) {
 	go echoLoop(mt1, echo1Done)
 
 	// Verify initial connectivity.
-	if err := c.Send(wspulse.Frame{Event: "before", Payload: []byte(`"1"`)}); err != nil {
-		t.Fatalf("Send before kick: %v", err)
-	}
+	require.NoError(t, c.Send(wspulse.Frame{Event: "before", Payload: []byte(`"1"`)}), "Send before kick")
 	select {
 	case f := <-received:
-		if f.Event != "before" {
-			t.Fatalf("want event %q, got %q", "before", f.Event)
-		}
+		assert.Equal(t, "before", f.Event)
 	case <-time.After(time.Second):
 		t.Fatal("timed out waiting for echo before kick")
 	}
@@ -93,14 +88,10 @@ func TestAutoReconnect_ReconnectsAndDeliversMessages(t *testing.T) {
 	go echoLoop(mt2, echo2Done)
 
 	// Verify post-reconnect message delivery.
-	if err := c.Send(wspulse.Frame{Event: "after", Payload: []byte(`"2"`)}); err != nil {
-		t.Fatalf("Send after reconnect: %v", err)
-	}
+	require.NoError(t, c.Send(wspulse.Frame{Event: "after", Payload: []byte(`"2"`)}), "Send after reconnect")
 	select {
 	case f := <-received:
-		if f.Event != "after" {
-			t.Fatalf("want event %q, got %q", "after", f.Event)
-		}
+		assert.Equal(t, "after", f.Event)
 	case <-time.After(time.Second):
 		t.Fatal("timed out waiting for echo after reconnect")
 	}
@@ -122,9 +113,7 @@ func TestAutoReconnect_MaxRetriesExhausted_ClosesDone(t *testing.T) {
 		client.WithAutoReconnect(2, 100*time.Millisecond, 500*time.Millisecond),
 		client.WithOnDisconnect(func(err error) {}),
 	)
-	if err != nil {
-		t.Fatalf("Dial failed: %v", err)
-	}
+	require.NoError(t, err, "Dial failed")
 	t.Cleanup(func() { _ = c.Close() })
 
 	// Kill the first transport.
@@ -164,9 +153,7 @@ func TestAutoReconnect_CloseDuringBackoff(t *testing.T) {
 			}
 		}),
 	)
-	if err != nil {
-		t.Fatalf("Dial failed: %v", err)
-	}
+	require.NoError(t, err, "Dial failed")
 
 	// Kill the first transport.
 	mt1.InjectError(&net.OpError{Op: "read", Err: errors.New("connection reset")})
@@ -232,9 +219,7 @@ func TestAutoReconnect_MultipleRapidCycles(t *testing.T) {
 			}
 		}),
 	)
-	if err != nil {
-		t.Fatalf("Dial failed: %v", err)
-	}
+	require.NoError(t, err, "Dial failed")
 	t.Cleanup(func() { _ = c.Close() })
 
 	// Drain the initial dial signal from client.Dial().
@@ -279,24 +264,16 @@ func TestAutoReconnect_MultipleRapidCycles(t *testing.T) {
 	defer close(echoDone)
 	go echoLoop(transports[cycles], echoDone)
 
-	if err := c.Send(wspulse.Frame{Event: "final", Payload: []byte(`"ok"`)}); err != nil {
-		t.Fatalf("Send after cycles: %v", err)
-	}
+	require.NoError(t, c.Send(wspulse.Frame{Event: "final", Payload: []byte(`"ok"`)}), "Send after cycles")
 	select {
 	case f := <-received:
-		if f.Event != "final" {
-			t.Fatalf("want event %q, got %q", "final", f.Event)
-		}
+		assert.Equal(t, "final", f.Event)
 	case <-time.After(time.Second):
 		t.Fatal("timed out waiting for echo after rapid cycles")
 	}
 
-	if dc := dropCount.Load(); dc < int32(cycles) {
-		t.Errorf("transport drop count = %d, want >= %d", dc, cycles)
-	}
-	if rc := restoreCount.Load(); rc < int32(cycles) {
-		t.Errorf("transport restore count = %d, want >= %d", rc, cycles)
-	}
+	assert.GreaterOrEqual(t, dropCount.Load(), int32(cycles), "transport drop count")
+	assert.GreaterOrEqual(t, restoreCount.Load(), int32(cycles), "transport restore count")
 }
 
 func TestAutoReconnect_Close_FiresOnDisconnect(t *testing.T) {
@@ -325,9 +302,7 @@ func TestAutoReconnect_Close_FiresOnDisconnect(t *testing.T) {
 	go echoLoop(mt, echoDone)
 
 	// Confirm the connection is established by round-tripping a frame.
-	if err := c.Send(wspulse.Frame{Event: "ping", Payload: []byte(`"1"`)}); err != nil {
-		t.Fatalf("Send failed: %v", err)
-	}
+	require.NoError(t, c.Send(wspulse.Frame{Event: "ping", Payload: []byte(`"1"`)}), "Send failed")
 	select {
 	case <-received:
 	case <-time.After(time.Second):

--- a/testhelpers_test.go
+++ b/testhelpers_test.go
@@ -8,6 +8,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	wspulse "github.com/wspulse/core"
 
 	"github.com/wspulse/client-go"
@@ -138,9 +140,7 @@ func dialWithMock(t *testing.T, opts ...client.ClientOption) (client.Client, *mo
 	}
 	allOpts = append(allOpts, opts...)
 	c, err := client.Dial("ws://mock", allOpts...)
-	if err != nil {
-		t.Fatalf("Dial failed: %v", err)
-	}
+	require.NoError(t, err, "Dial failed")
 	return c, mt, fc
 }
 


### PR DESCRIPTION
## Summary

Adopt `github.com/stretchr/testify` (`require`/`assert`) across all test files for clearer assertions and better failure messages. Replaces raw `t.Fatal`/`t.Errorf` + manual `if` checks. Mentions wspulse/.github#19.

## Changes

- 8 test files migrated: `backoff_test.go`, `basic_test.go`, `callback_test.go`, `client_test.go`, `lifecycle_test.go`, `misc_test.go`, `reconnect_test.go`, `testhelpers_test.go`
- `require` for setup/preconditions (fail-fast), `assert` for verification checks
- Panic tests simplified with `require.PanicsWithValue`
- No production code changes, no new test cases

## Checklist

### Required

- [x] `make check` passes (`fmt` → `lint` → `test`)
- [x] Each commit represents exactly one logical change
- [x] Commit messages follow the format in `commit-message-instructions.md`
- [x] No unrelated code reformatting in this PR