### PR TITLE
fix: add c.done priority check to writePump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- `writePump` now checks `c.done` before draining `c.send`, ensuring buffered frames are discarded on `Close()` per the behaviour contract
+
 ---
 
 ## [0.5.0] - 2026-04-04

--- a/basic_test.go
+++ b/basic_test.go
@@ -91,6 +91,10 @@ func TestClose_DiscardsBufferedFrames(t *testing.T) {
 		client.WithSendBufferSize(bufSize),
 	)
 	require.NoError(t, err)
+	t.Cleanup(func() {
+		unblock()
+		_ = c.Close()
+	})
 
 	// Send one frame — writePump picks it from c.send and blocks in WriteMessage.
 	require.NoError(t, c.Send(wspulse.Frame{Event: "first"}))

--- a/basic_test.go
+++ b/basic_test.go
@@ -73,6 +73,58 @@ func TestSend_WritesCorrectData(t *testing.T) {
 	assert.Equal(t, "test", wireFrame.Event)
 }
 
+func TestClose_DiscardsBufferedFrames(t *testing.T) {
+	t.Parallel()
+	// Contract: close() discards unsent buffered frames. After Close(),
+	// writePump must write at most 1 data frame (the one in-flight when
+	// c.done fires) before stopping.
+	const bufSize = 8
+	mt := newMockTransport()
+	fc := newFakeClock()
+	mt.writeEntered = make(chan struct{}, 16)
+	unblock := mt.BlockWrites()
+
+	md := newMockDialer(mockDialResult{transport: mt})
+	c, err := client.Dial("ws://mock",
+		client.WithDialer(md),
+		client.WithClock(fc),
+		client.WithSendBufferSize(bufSize),
+	)
+	require.NoError(t, err)
+
+	// Send one frame — writePump picks it from c.send and blocks in WriteMessage.
+	require.NoError(t, c.Send(wspulse.Frame{Event: "first"}))
+	<-mt.writeEntered // writePump is now blocked in WriteMessage
+
+	// Fill the remaining buffer — these frames sit in c.send.
+	for i := 0; i < bufSize-1; i++ {
+		require.NoError(t, c.Send(wspulse.Frame{Event: "buffered"}))
+	}
+
+	// Close in a goroutine — c.done closes immediately, then waits for goroutines.
+	closeDone := make(chan error, 1)
+	go func() { closeDone <- c.Close() }()
+	<-c.Done() // c.done is now closed
+
+	// Unblock the in-flight write — writePump completes it, loops back,
+	// hits the c.done priority check, sends CloseMessage, and exits.
+	unblock()
+	require.NoError(t, <-closeDone)
+
+	// Count data frames written to the transport.
+	writes := mt.DrainWrites()
+	dataFrames := 0
+	for _, w := range writes {
+		if w.messageType == 1 { // TextMessage
+			dataFrames++
+		}
+	}
+	// Priority check guarantees at most 1 data frame (the in-flight one).
+	// The remaining 7 frames in c.send are discarded.
+	require.LessOrEqual(t, dataFrames, 1,
+		"expected at most 1 data frame (in-flight), got %d", dataFrames)
+}
+
 func TestNormalCloseFrame(t *testing.T) {
 	t.Parallel()
 	// When the client calls Close(), writePump should send a WebSocket close

--- a/client.go
+++ b/client.go
@@ -250,6 +250,13 @@ func (c *internalClient) writePump(wsConnection wspulse.Transport, connectionQui
 	writeWait := c.config.writeWait
 	pingPeriod := c.config.pingPeriod
 
+	sendClose := func() {
+		_ = wsConnection.SetWriteDeadline(time.Now().Add(writeWait))
+		_ = wsConnection.WriteMessage(websocket.CloseMessage,
+			websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""),
+		)
+	}
+
 	ticker := c.clock.NewTicker(pingPeriod)
 	defer func() {
 		ticker.Stop()
@@ -258,9 +265,20 @@ func (c *internalClient) writePump(wsConnection wspulse.Transport, connectionQui
 	}()
 
 	for {
+		// Reconnect priority check — yield immediately so the new
+		// writePump can take over on a fresh connection.
 		select {
 		case <-connectionQuit:
 			c.logger.Debug("wspulse: writePump yielding for reconnect (priority)")
+			return
+		default:
+		}
+
+		// Close priority check — discard buffered frames on shutdown.
+		select {
+		case <-c.done:
+			c.logger.Debug("wspulse: writePump stopping (client closed)")
+			sendClose()
 			return
 		default:
 		}
@@ -286,10 +304,7 @@ func (c *internalClient) writePump(wsConnection wspulse.Transport, connectionQui
 
 		case <-c.done:
 			c.logger.Debug("wspulse: writePump stopping (client closed)")
-			_ = wsConnection.SetWriteDeadline(time.Now().Add(writeWait))
-			_ = wsConnection.WriteMessage(websocket.CloseMessage,
-				websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""),
-			)
+			sendClose()
 			return
 
 		case <-connectionQuit:

--- a/mock_transport_test.go
+++ b/mock_transport_test.go
@@ -25,6 +25,7 @@ type mockTransport struct {
 	mu           sync.Mutex
 	readLimit    int64
 	readLimitSet chan struct{} // signaled once when SetReadLimit is first called with a non-zero value
+	writeEntered chan struct{} // when non-nil, signaled each time WriteMessage is entered (before blocking)
 	pongHandler  func(string) error
 	closed       bool
 }
@@ -65,7 +66,16 @@ func (m *mockTransport) WriteMessage(messageType int, data []byte) error {
 		return &net.OpError{Op: "write", Err: net.ErrClosed}
 	}
 	blockCh := m.blockCh
+	writeEntered := m.writeEntered
 	m.mu.Unlock()
+
+	// Signal entry before blocking so tests can synchronize.
+	if writeEntered != nil {
+		select {
+		case writeEntered <- struct{}{}:
+		default:
+		}
+	}
 
 	// When blockCh is set, block until unblock is called or the transport
 	// is closed. After unblock, blockCh is cleared so writes resume normally.


### PR DESCRIPTION
## Summary

Add a `c.done` priority check to `writePump` so buffered frames are discarded on `Close()`, complying with the behaviour contract.

## Related issues

Closes #27
Relates to wspulse/.github#30

## Changes

- Extract `sendClose` closure in `writePump` to deduplicate CloseMessage sending logic
- Add non-blocking `c.done` priority check between existing `connectionQuit` check and main `select` — mirrors the same pattern already used for `connectionQuit`
- Add `TestClose_DiscardsBufferedFrames` component test using `BlockWrites` + `writeEntered` synchronization for deterministic verification
- Add `writeEntered` notification to `mockTransport` (nil by default, zero impact on existing tests)
- CHANGELOG entry under Unreleased/Fixed

## Checklist

### Required

- [x] `make check` passes (`fmt` → `lint` → `test`)
- [x] Each commit represents exactly one logical change
- [x] Commit messages follow the format in `commit-message-instructions.md`
- [x] No unrelated code reformatting in this PR

### Conditional

- [x] Bug fix: includes a test that fails before the fix and passes after
- [x] `Send` and `Close` remain safe for concurrent use