### PR TITLE
fix: onTransportDrop receives nil on Close()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - `writePump` now checks `c.done` before draining `c.send`, ensuring buffered frames are discarded on `Close()` per the behaviour contract
+- `onTransportDrop` now receives `nil` when triggered by `Close()`, matching the behaviour contract. Previously it received a misleading read-side error ("use of closed network connection").
 
 ---
 

--- a/callback_test.go
+++ b/callback_test.go
@@ -157,6 +157,64 @@ func TestClose_OnDisconnectFiresExactlyOnce(t *testing.T) {
 	assert.Equal(t, 1, dc, "onDisconnect fired count")
 }
 
+// ── onTransportDrop error value ──────────────────────────────────────────────
+
+func TestOnTransportDrop_NilOnClose(t *testing.T) {
+	t.Parallel()
+	transportDropErr := make(chan error, 1)
+	c, _, _ := dialWithMock(t,
+		client.WithOnTransportDrop(func(err error) {
+			transportDropErr <- err
+		}),
+	)
+
+	_ = c.Close()
+
+	got := requireReceive(t, transportDropErr)
+	assert.NoError(t, got, "onTransportDrop should receive nil on user-initiated Close()")
+}
+
+func TestOnTransportDrop_NilOnClose_AutoReconnect(t *testing.T) {
+	t.Parallel()
+	mt := newMockTransport()
+	fc := newFakeClock()
+	md := newMockDialer(mockDialResult{transport: mt})
+
+	transportDropErr := make(chan error, 1)
+	c, err := client.Dial("ws://mock",
+		client.WithDialer(md),
+		client.WithClock(fc),
+		client.WithAutoReconnect(3, 100*time.Millisecond, 500*time.Millisecond),
+		client.WithOnTransportDrop(func(err error) {
+			transportDropErr <- err
+		}),
+	)
+	require.NoError(t, err, "Dial failed")
+
+	_ = c.Close()
+
+	got := requireReceive(t, transportDropErr)
+	assert.NoError(t, got, "onTransportDrop should receive nil on user-initiated Close() with auto-reconnect")
+}
+
+func TestOnTransportDrop_NonNilOnServerDrop(t *testing.T) {
+	t.Parallel()
+	transportDropErr := make(chan error, 1)
+	c, mt, _ := dialWithMock(t,
+		client.WithOnTransportDrop(func(err error) {
+			transportDropErr <- err
+		}),
+	)
+	t.Cleanup(func() { _ = c.Close() })
+
+	// Simulate server dropping the connection.
+	injectedErr := &net.OpError{Op: "read", Err: errors.New("connection reset")}
+	mt.InjectError(injectedErr)
+
+	got := requireReceive(t, transportDropErr)
+	assert.Error(t, got, "onTransportDrop should receive non-nil error on server-initiated drop")
+}
+
 func TestOnTransportDrop_FiresOnReconnect(t *testing.T) {
 	t.Parallel()
 	mt1 := newMockTransport()

--- a/client.go
+++ b/client.go
@@ -206,6 +206,14 @@ func (c *internalClient) readPump(wsConnection wspulse.Transport, dropped chan s
 		}
 		_ = wsConnection.Close()
 
+		// User-initiated close → onTransportDrop(nil) per behaviour contract.
+		// Same pattern as the no-reconnect goroutine's onDisconnect check.
+		select {
+		case <-c.done:
+			readErr = nil
+		default:
+		}
+
 		c.logger.Debug("wspulse: connection lost",
 			zap.Error(readErr),
 		)


### PR DESCRIPTION
## Summary

Fix `onTransportDrop` to receive `nil` when triggered by `Close()`, matching the behaviour contract. Previously it received a misleading read-side error ("use of closed network connection").

## Related issues

Closes #30

## Changes

- Added `c.done` check in `readPump`'s defer before firing `onTransportDrop`. When `c.done` is closed (user-initiated `Close()`), `readErr` is set to `nil`. This is the same pattern already used in the no-reconnect goroutine for `onDisconnect`.
- Added 3 tests: `TestOnTransportDrop_NilOnClose`, `TestOnTransportDrop_NilOnClose_AutoReconnect`, `TestOnTransportDrop_NonNilOnServerDrop`.
- Added CHANGELOG entry.

## Checklist

### Required

- [x] `make check` passes (`fmt` → `lint` → `test`)
- [x] Each commit represents exactly one logical change
- [x] Commit messages follow the format in `commit-message-instructions.md`
- [x] No unrelated code reformatting in this PR

### Conditional

- [x] Bug fix: includes a test that fails before the fix and passes after