### PR TITLE
fix: read writeErrCh before transport Close()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - `writePump` now checks `c.done` before draining `c.send`, ensuring buffered frames are discarded on `Close()` per the behaviour contract
 - `onTransportDrop` now receives `nil` when triggered by `Close()`, matching the behaviour contract. Previously it received a misleading read-side error ("use of closed network connection").
 - `onTransportDrop` now receives the original write error when `writePump` fails (e.g. write timeout). Previously the write error was discarded and `onTransportDrop` received a secondary read-side error.
+- Fixed a race where a close-induced write error could override the original read error in `onTransportDrop`. The `writeErrCh` read now happens before `wsConnection.Close()` to prevent spurious override.
 
 ---
 

--- a/callback_test.go
+++ b/callback_test.go
@@ -280,6 +280,51 @@ func TestOnTransportDrop_ReadError_NoWriteError(t *testing.T) {
 	assert.ErrorIs(t, got, readErr, "onTransportDrop should receive readPump's own error when no write error exists")
 }
 
+func TestOnTransportDrop_ReadError_NotOverriddenByCloseInducedWriteError(t *testing.T) {
+	t.Parallel()
+	injectedReadErr := errors.New("server connection reset")
+
+	mt := newMockTransport()
+	mt.writeEntered = make(chan struct{}, 1)
+	fc := newFakeClock()
+	md := newMockDialer(mockDialResult{transport: mt})
+
+	transportDropErr := make(chan error, 1)
+	c, err := client.Dial("ws://mock",
+		client.WithDialer(md),
+		client.WithClock(fc),
+		client.WithOnTransportDrop(func(err error) {
+			transportDropErr <- err
+		}),
+	)
+	require.NoError(t, err, "Dial failed")
+	t.Cleanup(func() { _ = c.Close() })
+
+	// Block writes and send a frame so writePump enters WriteMessage and blocks.
+	unblock := mt.BlockWrites()
+	defer unblock()
+	require.NoError(t, c.Send(wspulse.Frame{Event: "trigger"}))
+	<-mt.writeEntered // writePump is now blocked mid-WriteMessage
+
+	// closeHook runs inside Close() after closeCh is closed but before
+	// Close() returns. The sleep gives writePump time to wake up and send
+	// the close-induced write error on writeErrCh.
+	mt.closeHook = func() {
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	// Inject read error — readPump fails first.
+	// readPump's defer calls Close() → closeCh closes → writePump wakes up,
+	// WriteMessage returns net.ErrClosed, sends it on writeErrCh.
+	// closeHook delays Close() return so the spurious error lands before
+	// readPump checks writeErrCh.
+	mt.InjectError(injectedReadErr)
+
+	got := requireReceive(t, transportDropErr)
+	assert.ErrorIs(t, got, injectedReadErr,
+		"onTransportDrop should receive the original read error, not a close-induced write error")
+}
+
 func TestOnTransportDrop_WriteError_Reconnect_CleanCycle(t *testing.T) {
 	t.Parallel()
 	writeErr := errors.New("i/o timeout")

--- a/callback_test.go
+++ b/callback_test.go
@@ -301,23 +301,34 @@ func TestOnTransportDrop_ReadError_NotOverriddenByCloseInducedWriteError(t *test
 	t.Cleanup(func() { _ = c.Close() })
 
 	// Block writes and send a frame so writePump enters WriteMessage and blocks.
-	unblock := mt.BlockWrites()
+	rawUnblock := mt.BlockWrites()
+	var unblockOnce sync.Once
+	unblock := func() { unblockOnce.Do(rawUnblock) }
 	defer unblock()
 	require.NoError(t, c.Send(wspulse.Frame{Event: "trigger"}))
 	<-mt.writeEntered // writePump is now blocked mid-WriteMessage
 
+	closeStarted := make(chan struct{})
+	writeReleased := make(chan struct{})
+
 	// closeHook runs inside Close() after closeCh is closed but before
-	// Close() returns. The sleep gives writePump time to wake up and send
-	// the close-induced write error on writeErrCh.
+	// Close() returns. It signals closeStarted, then waits for the blocked
+	// write to be released — ensuring writePump's close-induced error lands
+	// on writeErrCh before Close() returns. Zero real-time sleeps.
 	mt.closeHook = func() {
-		time.Sleep(10 * time.Millisecond)
+		close(closeStarted)
+		<-writeReleased
 	}
+	go func() {
+		<-closeStarted
+		unblock() // release blocked WriteMessage → returns net.ErrClosed → sends on writeErrCh
+		close(writeReleased)
+	}()
 
 	// Inject read error — readPump fails first.
-	// readPump's defer calls Close() → closeCh closes → writePump wakes up,
-	// WriteMessage returns net.ErrClosed, sends it on writeErrCh.
-	// closeHook delays Close() return so the spurious error lands before
-	// readPump checks writeErrCh.
+	// readPump's defer calls Close() → closeCh closes → closeHook fires →
+	// helper goroutine unblocks writePump → writePump sends close-induced
+	// error on writeErrCh → closeHook returns → Close() returns.
 	mt.InjectError(injectedReadErr)
 
 	got := requireReceive(t, transportDropErr)

--- a/client.go
+++ b/client.go
@@ -205,6 +205,16 @@ func (c *internalClient) readPump(wsConnection wspulse.Transport, dropped chan s
 				zap.Any("panic", r),
 			)
 		}
+		// Capture any write error BEFORE closing the transport.
+		// If writePump already failed, its error is on the channel.
+		// Reading before Close() prevents a spurious close-induced
+		// write error from overriding the original readErr.
+		var writeErr error
+		select {
+		case writeErr = <-writeErrCh:
+		default:
+		}
+
 		_ = wsConnection.Close()
 
 		// Determine the root-cause error for onTransportDrop:
@@ -215,10 +225,8 @@ func (c *internalClient) readPump(wsConnection wspulse.Transport, dropped chan s
 		case <-c.done:
 			readErr = nil
 		default:
-			select {
-			case writeErr := <-writeErrCh:
+			if writeErr != nil {
 				readErr = writeErr
-			default:
 			}
 		}
 

--- a/mock_transport_test.go
+++ b/mock_transport_test.go
@@ -27,7 +27,8 @@ type mockTransport struct {
 	readLimitSet chan struct{} // signaled once when SetReadLimit is first called with a non-zero value
 	writeEntered chan struct{} // when non-nil, signaled each time WriteMessage is entered (before blocking)
 	pongHandler  func(string) error
-	writeErr     error // when non-nil, WriteMessage returns this error immediately
+	writeErr     error  // when non-nil, WriteMessage returns this error immediately
+	closeHook    func() // when non-nil, runs inside Close() after closeCh is closed but before Close() returns
 	closed       bool
 }
 
@@ -132,8 +133,12 @@ func (m *mockTransport) Close() error {
 	m.closeOnce.Do(func() {
 		m.mu.Lock()
 		m.closed = true
+		hook := m.closeHook
 		m.mu.Unlock()
 		close(m.closeCh)
+		if hook != nil {
+			hook()
+		}
 	})
 	return nil
 }


### PR DESCRIPTION
## Summary

Fix a race where a close-induced write error could override the original read error in `onTransportDrop`. The `writeErrCh` non-blocking receive now happens before `wsConnection.Close()`, ensuring only genuine write errors (not close-induced ones) are propagated.

## Related issues

Closes #33

## Changes

- `client.go`: moved `writeErrCh` read before `wsConnection.Close()` in readPump's defer. If writePump already failed, its error is captured before Close() can trigger a spurious write error.
- `mock_transport_test.go`: added `closeHook func()` field to mockTransport. When set, runs synchronously inside `Close()` after `closeCh` is closed but before `Close()` returns. This allows tests to deterministically reproduce the race.
- `callback_test.go`: added `TestOnTransportDrop_ReadError_NotOverriddenByCloseInducedWriteError` — blocks writePump mid-WriteMessage, injects read error, uses closeHook to ensure writePump sends close-induced error before readPump checks writeErrCh.
- CHANGELOG entry.

## Checklist

### Required

- [x] `make check` passes (`fmt` → `lint` → `test`)
- [x] Each commit represents exactly one logical change
- [x] Commit messages follow the format in `commit-message-instructions.md`
- [x] No unrelated code reformatting in this PR

### Conditional

- [x] Bug fix: includes a test that fails before the fix and passes after
- [x] `Send` and `Close` remain safe for concurrent use