### PR TITLE
test: audit and fix misleading test names

### DIFF
--- a/callback_test.go
+++ b/callback_test.go
@@ -383,7 +383,7 @@ func TestOnTransportDrop_WriteError_Reconnect_CleanCycle(t *testing.T) {
 	assert.ErrorIs(t, got2, readErr, "second drop should report read error, not stale write error from first cycle")
 }
 
-func TestOnTransportDrop_Fires_WithAutoReconnect(t *testing.T) {
+func TestOnTransportDrop_Fires_AutoReconnect(t *testing.T) {
 	t.Parallel()
 	mt1 := newMockTransport()
 	mt2 := newMockTransport()

--- a/callback_test.go
+++ b/callback_test.go
@@ -383,7 +383,7 @@ func TestOnTransportDrop_WriteError_Reconnect_CleanCycle(t *testing.T) {
 	assert.ErrorIs(t, got2, readErr, "second drop should report read error, not stale write error from first cycle")
 }
 
-func TestOnTransportDrop_FiresOnReconnect(t *testing.T) {
+func TestOnTransportDrop_Fires_WithAutoReconnect(t *testing.T) {
 	t.Parallel()
 	mt1 := newMockTransport()
 	mt2 := newMockTransport()

--- a/doc/component-tests.md
+++ b/doc/component-tests.md
@@ -82,4 +82,4 @@ deterministic and run with `make check`.
 | `TestWithHeartbeat_SendsPings`                     | Ping messages are sent at configured interval                 |
 | `TestWithLogger_ValidLogger_Applied`               | `WithLogger` option is accepted                               |
 
-**Total: 41 component tests** (9 contract scenarios + 32 additional).
+**Total: 41 component tests** (9 contract scenarios + additional per-feature tests).

--- a/doc/component-tests.md
+++ b/doc/component-tests.md
@@ -43,7 +43,7 @@ deterministic and run with `make check`.
 | `TestOnDisconnect_NonNilOnServerDrop`              | `onDisconnect` receives non-nil error on server drop               |
 | `TestOnDisconnect_NonNilOnMaxRetries`              | `onDisconnect` receives non-nil error when retries exhausted       |
 | `TestClose_OnDisconnectFiresExactlyOnce`           | `onDisconnect` fires exactly once on `Close()`                     |
-| `TestOnTransportDrop_Fires_WithAutoReconnect`      | `onTransportDrop` fires when transport drops (autoReconnect)       |
+| `TestOnTransportDrop_Fires_AutoReconnect`           | `onTransportDrop` fires when transport drops (autoReconnect)       |
 | `TestOnTransportRestore_FiresAfterReconnect`       | `onTransportRestore` fires after successful reconnect              |
 | `TestOnTransportRestore_DoesNotFireOnInitialConnect`| `onTransportRestore` does not fire on first connect               |
 | `TestOnTransportRestore_NotFiredOnFailedReconnect` | `onTransportRestore` does not fire when reconnect fails            |

--- a/doc/component-tests.md
+++ b/doc/component-tests.md
@@ -14,12 +14,12 @@ deterministic and run with `make check`.
 | #   | Scenario                                                            | Test Name                                                    | File                |
 | --- | ------------------------------------------------------------------- | ------------------------------------------------------------ | ------------------- |
 | 1   | Connect, send, echo, close clean                                    | `TestSendAndReceive`                                         | basic_test.go       |
-| 2   | Server drops, onTransportDrop + onDisconnect (no reconnect)         | `TestOnDisconnect_IsErrConnectionLostOnServerDrop`           | callback_test.go    |
+| 2   | Server drops, onTransportDrop + onDisconnect (no reconnect)         | `TestOnDisconnect_IsErrConnectionLostOnServerDrop`, `TestOnTransportDrop_NonNilOnServerDrop` | callback_test.go    |
 | 3   | Auto-reconnect: server drops, reconnects within maxRetries          | `TestAutoReconnect_ReconnectsAndDeliversMessages`            | reconnect_test.go   |
 | 4   | Max retries exhausted, `Done()` closes                              | `TestAutoReconnect_MaxRetriesExhausted_ClosesDone`           | reconnect_test.go   |
 | 5   | `Close()` during reconnect/backoff, loop stops cleanly              | `TestAutoReconnect_CloseDuringBackoff`                       | reconnect_test.go   |
 | 6   | `Send()` on closed client, `ErrConnectionClosed`                    | `TestSend_AfterClose_ReturnsErrConnectionClosed`             | basic_test.go       |
-| 7   | Heartbeat ping then read error, client disconnects with non-nil error | `TestHeartbeatPongTimeout_DisconnectsClient`                 | misc_test.go        |
+| 7   | Heartbeat ping then read error, client disconnects with non-nil error | `TestHeartbeat_ReadError_DisconnectsClient`                  | misc_test.go        |
 | 8   | Concurrent sends: no data race or interleaving                      | `TestConcurrentSendAndClose_NoRace`                          | lifecycle_test.go   |
 | 9   | Concurrent `Close()` + transport drop, `onDisconnect` exactly once  | `TestConcurrentCloseAndTransportDrop_OnDisconnectExactlyOnce`| lifecycle_test.go   |
 
@@ -43,7 +43,7 @@ deterministic and run with `make check`.
 | `TestOnDisconnect_NonNilOnServerDrop`              | `onDisconnect` receives non-nil error on server drop               |
 | `TestOnDisconnect_NonNilOnMaxRetries`              | `onDisconnect` receives non-nil error when retries exhausted       |
 | `TestClose_OnDisconnectFiresExactlyOnce`           | `onDisconnect` fires exactly once on `Close()`                     |
-| `TestOnTransportDrop_FiresOnReconnect`             | `onTransportDrop` fires when transport drops (autoReconnect)       |
+| `TestOnTransportDrop_Fires_WithAutoReconnect`      | `onTransportDrop` fires when transport drops (autoReconnect)       |
 | `TestOnTransportRestore_FiresAfterReconnect`       | `onTransportRestore` fires after successful reconnect              |
 | `TestOnTransportRestore_DoesNotFireOnInitialConnect`| `onTransportRestore` does not fire on first connect               |
 | `TestOnTransportRestore_NotFiredOnFailedReconnect` | `onTransportRestore` does not fire when reconnect fails            |

--- a/misc_test.go
+++ b/misc_test.go
@@ -118,7 +118,7 @@ func TestSend_EncodeError_ReturnsError(t *testing.T) {
 	require.Error(t, err, "expected encode error")
 }
 
-func TestHeartbeatPongTimeout_DisconnectsClient(t *testing.T) {
+func TestHeartbeat_ReadError_DisconnectsClient(t *testing.T) {
 	t.Parallel()
 	// Verifies the observable heartbeat behaviour: the client sends pings
 	// via the heartbeat ticker, and when the transport dies the client disconnects.


### PR DESCRIPTION
## Summary

Audit all test names and scenario descriptions for accuracy, renaming misleading functions and fixing incomplete scenario mappings. Resolves deferred rename from PR #23 review.

## Related issues

Closes #28

## Changes

- Rename `TestHeartbeatPongTimeout_DisconnectsClient` → `TestHeartbeat_ReadError_DisconnectsClient` in `misc_test.go` — the test injects a read error after observing a ping, not a pong timeout
- Rename `TestOnTransportDrop_FiresOnReconnect` → `TestOnTransportDrop_Fires_AutoReconnect` in `callback_test.go` — the callback fires on transport drop (before reconnect), not during reconnection; suffix aligned to existing `_AutoReconnect` convention
- Add `TestOnTransportDrop_NonNilOnServerDrop` as second reference in scenario #2 of `doc/component-tests.md` — the scenario describes both `onTransportDrop` and `onDisconnect` but previously only mapped the `onDisconnect` test
- Update all test name references in `doc/component-tests.md` tables
- Fix total wording to not assume 1:1 scenario-to-test mapping

**Audit result:** 39/41 test names were accurate. No production code changes.

## Checklist

### Required

- [x] `make check` passes (`fmt` → `lint` → `test`)
- [x] Each commit represents exactly one logical change
- [x] Commit messages follow the format in `commit-message-instructions.md`
- [x] No unrelated code reformatting in this PR