### PR TITLE
chore: release v0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+---
+
+## [0.5.1] - 2026-04-08
+
 ### Fixed
 
 - `writePump` now checks `c.done` before draining `c.send`, ensuring buffered frames are discarded on `Close()` per the behaviour contract
@@ -131,7 +135,8 @@
 - Orphaned callback goroutines on disconnect — all goroutines cleaned up on `Close`
 - `Close()` waits for all internal goroutines to exit before returning
 
-[Unreleased]: https://github.com/wspulse/client-go/compare/v0.5.0...HEAD
+[Unreleased]: https://github.com/wspulse/client-go/compare/v0.5.1...HEAD
+[0.5.1]: https://github.com/wspulse/client-go/compare/v0.5.0...v0.5.1
 [0.5.0]: https://github.com/wspulse/client-go/compare/v0.4.1...v0.5.0
 [0.4.1]: https://github.com/wspulse/client-go/compare/v0.4.0...v0.4.1
 [0.4.0]: https://github.com/wspulse/client-go/compare/v0.3.0...v0.4.0


### PR DESCRIPTION
## Summary

Stamp CHANGELOG [Unreleased] as v0.5.1 with today's date. No code changes — release bookkeeping only.

## Changes

- Move four Fixed entries from [Unreleased] to [0.5.1] - 2026-04-08
- Add v0.5.1 comparison link to CHANGELOG footer

## Checklist

### Required

- [x] `make check` passes (`fmt` → `lint` → `test`)
- [x] Each commit represents exactly one logical change
- [x] Commit messages follow the format in `commit-message-instructions.md`
- [x] No unrelated code reformatting in this PR