### PR TITLE
refactor: migrate from gorilla/websocket to coder/websocket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## [Unreleased]
 
+### Changed
+
+- **BREAKING**: Replace `gorilla/websocket` (archived) with `coder/websocket` as the underlying WebSocket transport
+- **BREAKING**: Remove `WithHeartbeat(pingPeriod, pongWait, writeWait)` option; replaced by two independent options:
+  - `WithPingInterval(d time.Duration)` — heartbeat interval (default 20s, max 1m)
+  - `WithWriteTimeout(d time.Duration)` — write/pong deadline (default 10s, max 30s)
+- Extract `pingPump` as a dedicated goroutine (was inlined in `writePump`), giving a 3-pump architecture: readPump + writePump + pingPump
+- Internal `dialer` interface now accepts `context.Context`; reconnect dial is cancellable via `Close()`
+
 ---
 
 ## [0.5.1] - 2026-04-08

--- a/README.md
+++ b/README.md
@@ -137,7 +137,8 @@ See [wspulse/core](https://github.com/wspulse/core) for the full `router` API.
 | `WithOnDisconnect(fn)`                   | —               |
 | `WithOnTransportDrop(fn)`                | —               |
 | `WithAutoReconnect(max, base, maxDelay)` | disabled              |
-| `WithHeartbeat(ping, pong, writeWait)`   | 20s / 60s / 10s       |
+| `WithPingInterval(d)`                    | 20s                   |
+| `WithWriteTimeout(d)`                    | 10s                   |
 | `WithMaxMessageSize(n)`                  | 1 MiB                 |
 | `WithCodec(c)`                           | JSONCodec             |
 | `WithDialHeaders(h)`                     | —                     |

--- a/TODOS.md
+++ b/TODOS.md
@@ -1,8 +1,0 @@
-# TODOS
-
-Items deferred from code review. Each entry links to the original comment.
-
----
-
-- **Propagate pong timeout root cause to onTransportDrop** — currently onTransportDrop receives `net.ErrClosed` (from readPump) instead of the original `context.DeadlineExceeded` (from pingPump). Requires a cross-pump error channel. Low priority: behaviour contract does not mandate root-cause fidelity in onTransportDrop.
-  - Source: [PR #43 comment](https://github.com/wspulse/client-go/pull/43#discussion_r3069131109)

--- a/TODOS.md
+++ b/TODOS.md
@@ -1,0 +1,8 @@
+# TODOS
+
+Items deferred from code review. Each entry links to the original comment.
+
+---
+
+- **Propagate pong timeout root cause to onTransportDrop** — currently onTransportDrop receives `net.ErrClosed` (from readPump) instead of the original `context.DeadlineExceeded` (from pingPump). Requires a cross-pump error channel. Low priority: behaviour contract does not mandate root-cause fidelity in onTransportDrop.
+  - Source: [PR #43 comment](https://github.com/wspulse/client-go/pull/43#discussion_r3069131109)

--- a/basic_test.go
+++ b/basic_test.go
@@ -62,7 +62,7 @@ func TestSend_WritesCorrectData(t *testing.T) {
 	require.NoError(t, c.Send(frame), "Send failed")
 
 	w := requireReceive(t, mt.writeCh)
-	assert.Equal(t, 1, w.messageType, "messageType") // TextMessage (JSONCodec)
+	assert.Equal(t, wspulse.TextMessage, w.messageType, "messageType")
 
 	// Decode the written data and verify.
 	var wireFrame struct {
@@ -96,9 +96,9 @@ func TestClose_DiscardsBufferedFrames(t *testing.T) {
 		_ = c.Close()
 	})
 
-	// Send one frame — writePump picks it from c.send and blocks in WriteMessage.
+	// Send one frame — writePump picks it from c.send and blocks in Write.
 	require.NoError(t, c.Send(wspulse.Frame{Event: "first"}))
-	<-mt.writeEntered // writePump is now blocked in WriteMessage
+	<-mt.writeEntered // writePump is now blocked in Write
 
 	// Fill the remaining buffer — these frames sit in c.send.
 	for i := 0; i < bufSize-1; i++ {
@@ -111,7 +111,7 @@ func TestClose_DiscardsBufferedFrames(t *testing.T) {
 	<-c.Done() // c.done is now closed
 
 	// Unblock the in-flight write — writePump completes it, loops back,
-	// hits the c.done priority check, sends CloseMessage, and exits.
+	// hits the c.done priority check, and exits.
 	unblock()
 	require.NoError(t, <-closeDone)
 
@@ -119,7 +119,7 @@ func TestClose_DiscardsBufferedFrames(t *testing.T) {
 	writes := mt.DrainWrites()
 	dataFrames := 0
 	for _, w := range writes {
-		if w.messageType == 1 { // TextMessage
+		if w.messageType == wspulse.TextMessage {
 			dataFrames++
 		}
 	}
@@ -132,20 +132,22 @@ func TestClose_DiscardsBufferedFrames(t *testing.T) {
 func TestNormalCloseFrame(t *testing.T) {
 	t.Parallel()
 	// When the client calls Close(), writePump should send a WebSocket close
-	// frame (messageType 8) before exiting.
-	c, mt, _ := dialWithMock(t)
+	// frame with StatusNormalClosure before exiting.
+	mt := newMockTransport()
+	mt.closeCalled = make(chan closeCall, 1)
+	fc := newFakeClock()
+	md := newMockDialer(mockDialResult{transport: mt})
+
+	c, err := client.Dial("ws://mock",
+		client.WithDialer(md),
+		client.WithClock(fc),
+	)
+	require.NoError(t, err)
 
 	_ = c.Close()
 
-	// Close() blocks until writePump exits — drain immediately.
-	writes := mt.DrainWrites()
-
-	foundClose := false
-	for _, w := range writes {
-		if w.messageType == 8 { // CloseMessage
-			foundClose = true
-			break
-		}
-	}
-	assert.True(t, foundClose, "Close() did not produce a WebSocket close frame (messageType=8)")
+	// Close() blocks until writePump exits — check immediately.
+	cc := requireReceive(t, mt.closeCalled)
+	assert.Equal(t, wspulse.StatusNormalClosure, cc.code,
+		"Close() did not produce a close frame with StatusNormalClosure")
 }

--- a/callback_test.go
+++ b/callback_test.go
@@ -234,34 +234,6 @@ func TestOnTransportDrop_WritePumpDataWriteError(t *testing.T) {
 	assert.ErrorIs(t, got, writeErr, "onTransportDrop should receive the write error, not a read-side error")
 }
 
-func TestOnTransportDrop_WritePumpPingWriteError(t *testing.T) {
-	t.Parallel()
-	writeErr := errors.New("i/o timeout")
-	mt := newMockTransport()
-	fc := newFakeClock()
-	md := newMockDialer(mockDialResult{transport: mt})
-
-	transportDropErr := make(chan error, 1)
-	c, err := client.Dial("ws://mock",
-		client.WithDialer(md),
-		client.WithClock(fc),
-		client.WithOnTransportDrop(func(err error) {
-			transportDropErr <- err
-		}),
-	)
-	require.NoError(t, err, "Dial failed")
-	t.Cleanup(func() { _ = c.Close() })
-
-	// Wait for the ticker to be registered, then inject write error and fire tick.
-	<-fc.tickerAdded
-	mt.SetWriteError(writeErr)
-	fc.fireTicker(0)
-
-	got := requireReceive(t, transportDropErr)
-	fc.stopTicker(0)
-	assert.ErrorIs(t, got, writeErr, "onTransportDrop should receive the ping write error, not a read-side error")
-}
-
 func TestOnTransportDrop_ReadError_NoWriteError(t *testing.T) {
 	t.Parallel()
 	readErr := &net.OpError{Op: "read", Err: errors.New("connection reset")}
@@ -300,35 +272,35 @@ func TestOnTransportDrop_ReadError_NotOverriddenByCloseInducedWriteError(t *test
 	require.NoError(t, err, "Dial failed")
 	t.Cleanup(func() { _ = c.Close() })
 
-	// Block writes and send a frame so writePump enters WriteMessage and blocks.
+	// Block writes and send a frame so writePump enters Write and blocks.
 	rawUnblock := mt.BlockWrites()
 	var unblockOnce sync.Once
 	unblock := func() { unblockOnce.Do(rawUnblock) }
 	defer unblock()
 	require.NoError(t, c.Send(wspulse.Frame{Event: "trigger"}))
-	<-mt.writeEntered // writePump is now blocked mid-WriteMessage
+	<-mt.writeEntered // writePump is now blocked mid-Write
 
 	closeStarted := make(chan struct{})
 	writeReleased := make(chan struct{})
 
-	// closeHook runs inside Close() after closeCh is closed but before
-	// Close() returns. It signals closeStarted, then waits for the blocked
+	// closeHook runs inside doClose after closeCh is closed but before
+	// doClose returns. It signals closeStarted, then waits for the blocked
 	// write to be released — ensuring writePump's close-induced error lands
-	// on writeErrCh before Close() returns. Zero real-time sleeps.
+	// on writeErrCh before doClose returns. Zero real-time sleeps.
 	mt.closeHook = func() {
 		close(closeStarted)
 		<-writeReleased
 	}
 	go func() {
 		<-closeStarted
-		unblock() // release blocked WriteMessage → returns net.ErrClosed → sends on writeErrCh
+		unblock() // release blocked Write → returns net.ErrClosed → sends on writeErrCh
 		close(writeReleased)
 	}()
 
 	// Inject read error — readPump fails first.
-	// readPump's defer calls Close() → closeCh closes → closeHook fires →
+	// readPump's defer calls CloseNow() → closeCh closes → closeHook fires →
 	// helper goroutine unblocks writePump → writePump sends close-induced
-	// error on writeErrCh → closeHook returns → Close() returns.
+	// error on writeErrCh → closeHook returns → doClose returns.
 	mt.InjectError(injectedReadErr)
 
 	got := requireReceive(t, transportDropErr)

--- a/client.go
+++ b/client.go
@@ -231,7 +231,17 @@ func (c *internalClient) readPump(ctx context.Context, transport wspulse.Transpo
 		default:
 		}
 
-		_ = transport.CloseNow()
+		// On user-initiated close, skip CloseNow() here — writePump owns
+		// the graceful close handshake (close frame + deferred CloseNow).
+		// Calling CloseNow() first would kill the transport before writePump
+		// can send the close frame, causing the server to see an abnormal drop.
+		// On reconnect (c.done not closed), CloseNow() is correct — we want
+		// to force-kill the old transport immediately.
+		select {
+		case <-c.done:
+		default:
+			_ = transport.CloseNow()
+		}
 
 		// Determine the root-cause error for onTransportDrop:
 		//   1. User-initiated close → nil (behaviour contract).

--- a/client.go
+++ b/client.go
@@ -9,8 +9,9 @@ import (
 	"sync"
 	"time"
 
-	wspulse "github.com/wspulse/core"
 	"go.uber.org/zap"
+
+	wspulse "github.com/wspulse/core"
 )
 
 // ErrRetriesExhausted is returned to OnDisconnect when all reconnect

--- a/client.go
+++ b/client.go
@@ -395,10 +395,18 @@ func (c *internalClient) doPing(ctx context.Context, transport wspulse.Transport
 		if ctx.Err() != nil {
 			return err
 		}
-		// Pong timeout — force-close the transport to trigger readPump error.
-		c.logger.Warn("wspulse: pong timeout, closing transport",
-			zap.Error(err),
-		)
+		// Abnormal ping failure — force-close to trigger readPump error.
+		// Detailed error classification (timeout vs. TCP drop vs. policy)
+		// is handled in issue #44.
+		if errors.Is(err, context.DeadlineExceeded) {
+			c.logger.Warn("wspulse: pong timeout, closing transport",
+				zap.Error(err),
+			)
+		} else {
+			c.logger.Warn("wspulse: ping failed, closing transport",
+				zap.Error(err),
+			)
+		}
 		_ = transport.CloseNow()
 		return err
 	}
@@ -457,7 +465,9 @@ func (c *internalClient) reconnectLoop(dropped chan struct{}) {
 		dialCtx, dialCancel := context.WithCancel(context.Background())
 		// Cancel the in-flight dial immediately when Close() is called,
 		// so we don't block on a slow/unresponsive server handshake.
+		c.goroutineWaitGroup.Add(1)
 		go func() {
+			defer c.goroutineWaitGroup.Done()
 			select {
 			case <-c.quit:
 				dialCancel()

--- a/client.go
+++ b/client.go
@@ -9,9 +9,8 @@ import (
 	"sync"
 	"time"
 
-	"go.uber.org/zap"
-
 	wspulse "github.com/wspulse/core"
+	"go.uber.org/zap"
 )
 
 // ErrRetriesExhausted is returned to OnDisconnect when all reconnect
@@ -138,7 +137,7 @@ func Dial(urlStr string, opts ...ClientOption) (Client, error) {
 				c.mu.Unlock()
 			})
 			if fn := c.config.onDisconnect; fn != nil {
-				fn(disconnectErr)
+				c.safeInvoke("onDisconnect", func() { fn(disconnectErr) })
 			}
 		}()
 	}
@@ -257,11 +256,12 @@ func (c *internalClient) readPump(ctx context.Context, transport wspulse.Transpo
 		}
 
 		c.logger.Debug("wspulse: connection lost",
+			zap.String("url", c.url),
 			zap.Error(readErr),
 		)
 
 		if fn := c.config.onTransportDrop; fn != nil {
-			fn(readErr)
+			c.safeInvoke("onTransportDrop", func() { fn(readErr) })
 		}
 
 		close(dropped)
@@ -323,6 +323,7 @@ func (c *internalClient) writePump(ctx context.Context, transport wspulse.Transp
 			cancel()
 			if err != nil {
 				c.logger.Warn("wspulse: write failed",
+					zap.String("url", c.url),
 					zap.Error(err),
 				)
 				select {
@@ -360,12 +361,17 @@ func (c *internalClient) closeOrForce(transport wspulse.Transport) {
 // gracefulClose attempts to send a WebSocket close frame within
 // writeTimeout. If the transport blocks (e.g. dead peer), CloseNow
 // is called as a fallback to prevent hanging.
+//
+// transport.Close() has no context parameter, so we run it in a tracked
+// goroutine with a timer fallback. The goroutine is added to
+// goroutineWaitGroup so Close() does not return until it exits — even
+// when the timer fires and CloseNow() is called first.
 func (c *internalClient) gracefulClose(transport wspulse.Transport) {
 	done := make(chan struct{})
-	go func() {
+	c.goroutineWaitGroup.Go(func() {
 		_ = transport.Close(wspulse.StatusNormalClosure, "")
 		close(done)
-	}()
+	})
 	t := time.NewTimer(c.config.writeTimeout)
 	defer t.Stop()
 	select {
@@ -427,7 +433,7 @@ func (c *internalClient) reconnectLoop(dropped chan struct{}) {
 	var disconnectErr error
 	defer func() {
 		if fn := c.config.onDisconnect; fn != nil {
-			fn(disconnectErr)
+			c.safeInvoke("onDisconnect", func() { fn(disconnectErr) })
 		}
 	}()
 
@@ -553,9 +559,23 @@ func (c *internalClient) reconnectLoop(dropped chan struct{}) {
 		)
 		attempt = 0
 		if fn := c.config.onTransportRestore; fn != nil {
-			fn()
+			c.safeInvoke("onTransportRestore", func() { fn() })
 		}
 	}
+}
+
+// safeInvoke calls fn, recovering from any panic so a misbehaving user
+// callback cannot crash an internal goroutine.
+func (c *internalClient) safeInvoke(callback string, fn func()) {
+	defer func() {
+		if r := recover(); r != nil {
+			c.logger.Error("wspulse: callback panic recovered",
+				zap.String("callback", callback),
+				zap.Any("panic", r),
+			)
+		}
+	}()
+	fn()
 }
 
 // normalizeScheme converts http/https URL schemes to their WebSocket

--- a/client.go
+++ b/client.go
@@ -51,6 +51,8 @@ type Client interface {
 //     Close() (to shut down permanently).
 //   - pumpDone   : closed by writePump on exit; used by reconnectLoop
 //     to wait for the old pumps before starting new ones.
+//   - pingPump   : exits via context cancellation; its errors propagate
+//     through CloseNow() → readPump (which sees a read error).
 type internalClient struct {
 	url                string
 	config             *clientConfig
@@ -432,7 +434,18 @@ func (c *internalClient) reconnectLoop(dropped chan struct{}) {
 			zap.Int("attempt", attempt),
 			zap.String("url", c.url),
 		)
-		if err := c.dialOnce(context.Background()); err != nil {
+		dialCtx, dialCancel := context.WithCancel(context.Background())
+		// Cancel the in-flight dial immediately when Close() is called,
+		// so we don't block on a slow/unresponsive server handshake.
+		go func() {
+			select {
+			case <-c.quit:
+				dialCancel()
+			case <-dialCtx.Done():
+			}
+		}()
+		if err := c.dialOnce(dialCtx); err != nil {
+			dialCancel()
 			c.logger.Debug("wspulse: dial failed",
 				zap.Int("attempt", attempt),
 				zap.Error(err),
@@ -442,6 +455,8 @@ func (c *internalClient) reconnectLoop(dropped chan struct{}) {
 			close(dropped)
 			continue
 		}
+
+		dialCancel() // stop the quit-monitoring goroutine
 
 		select {
 		case <-c.quit:

--- a/client.go
+++ b/client.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"math/rand/v2"
@@ -8,7 +9,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/gorilla/websocket"
 	"go.uber.org/zap"
 
 	wspulse "github.com/wspulse/core"
@@ -39,14 +39,18 @@ type Client interface {
 // internalClient is the unexported, concrete implementation of Client.
 //
 // Signal channels:
-//   - done            : closed via once.Do on any permanent disconnect (explicit
+//   - done       : closed via once.Do on any permanent disconnect (explicit
 //     Close(), server drop without auto-reconnect, or max retries exhausted);
 //     signals Send() and writePump to stop.
-//   - quit            : closed together with done (same once.Do); signals
+//   - quit       : closed together with done (same once.Do); signals
 //     reconnectLoop to stop.
-//   - connectionQuit  : closed by reconnectLoop when it successfully reconnects,
-//     telling the OLD writePump to yield so the NEW one can take over.
-//     Swapped (replaced with a fresh channel) on each reconnect.
+//
+// Pump lifecycle:
+//   - pumpCancel : cancels the pump context, causing readPump, writePump,
+//     and pingPump to exit. Called on reconnect (to swap pumps) and on
+//     Close() (to shut down permanently).
+//   - pumpDone   : closed by writePump on exit; used by reconnectLoop
+//     to wait for the old pumps before starting new ones.
 type internalClient struct {
 	url                string
 	config             *clientConfig
@@ -55,13 +59,13 @@ type internalClient struct {
 	clock              clock
 	connection         wspulse.Transport
 	send               chan []byte
-	done               chan struct{}  // closed via once.Do on permanent disconnect
-	quit               chan struct{}  // closed together with done via once.Do
-	connectionQuit     chan struct{}  // closed to stop the current writePump; swapped on each reconnect
-	pumpDone           chan struct{}  // closed by writePump on exit; used by reconnectLoop to wait for the old pump
-	mu                 sync.Mutex     // guards connection, connectionQuit, and pumpDone across goroutines
-	once               sync.Once      // ensures Close() logic runs only once
-	goroutineWaitGroup sync.WaitGroup // tracks all internal goroutines so Close() can wait for their exit
+	done               chan struct{}      // closed via once.Do on permanent disconnect
+	quit               chan struct{}      // closed together with done via once.Do
+	pumpDone           chan struct{}      // closed by writePump on exit
+	pumpCancel         context.CancelFunc // cancels pump context to stop all pumps
+	mu                 sync.Mutex         // guards connection, pumpDone, and pumpCancel
+	once               sync.Once          // ensures Close() logic runs only once
+	goroutineWaitGroup sync.WaitGroup     // tracks all internal goroutines so Close() can wait
 }
 
 // Dial connects to urlStr and returns a Client.
@@ -77,32 +81,36 @@ func Dial(urlStr string, opts ...ClientOption) (Client, error) {
 	for _, o := range opts {
 		o(config)
 	}
-	connectionQuit := make(chan struct{})
-	pumpDone := make(chan struct{})
 	c := &internalClient{
-		url:            urlStr,
-		config:         config,
-		logger:         config.logger,
-		dialer:         config.dialer,
-		clock:          config.clock,
-		send:           make(chan []byte, config.sendBufferSize),
-		done:           make(chan struct{}),
-		quit:           make(chan struct{}),
-		connectionQuit: connectionQuit,
-		pumpDone:       pumpDone,
+		url:    urlStr,
+		config: config,
+		logger: config.logger,
+		dialer: config.dialer,
+		clock:  config.clock,
+		send:   make(chan []byte, config.sendBufferSize),
+		done:   make(chan struct{}),
+		quit:   make(chan struct{}),
 	}
-	if err := c.dialOnce(); err != nil {
+	if err := c.dialOnce(context.Background()); err != nil {
 		return nil, fmt.Errorf("wspulse: dial: %w", err)
 	}
 	c.logger.Debug("wspulse: connected",
 		zap.String("url", urlStr),
 	)
+
+	pumpCtx, pumpCancel := context.WithCancel(context.Background())
+	pumpDone := make(chan struct{})
 	dropped := make(chan struct{})
 	writeErrCh := make(chan error, 1)
-	c.goroutineWaitGroup.Add(3)
 	conn := c.connection
-	go func() { defer c.goroutineWaitGroup.Done(); c.writePump(conn, connectionQuit, pumpDone, writeErrCh) }()
-	go func() { defer c.goroutineWaitGroup.Done(); c.readPump(conn, dropped, writeErrCh) }()
+
+	c.pumpCancel = pumpCancel
+	c.pumpDone = pumpDone
+
+	c.goroutineWaitGroup.Add(4)
+	go func() { defer c.goroutineWaitGroup.Done(); c.readPump(pumpCtx, conn, dropped, writeErrCh) }()
+	go func() { defer c.goroutineWaitGroup.Done(); c.writePump(pumpCtx, conn, pumpDone, writeErrCh) }()
+	go func() { defer c.goroutineWaitGroup.Done(); c.pingPump(pumpCtx, conn) }()
 	if config.autoReconnect {
 		go func() { defer c.goroutineWaitGroup.Done(); c.reconnectLoop(dropped) }()
 	} else {
@@ -123,6 +131,9 @@ func Dial(urlStr string, opts ...ClientOption) (Client, error) {
 			c.once.Do(func() {
 				close(c.done)
 				close(c.quit)
+				c.mu.Lock()
+				c.pumpCancel()
+				c.mu.Unlock()
 			})
 			if fn := c.config.onDisconnect; fn != nil {
 				fn(disconnectErr)
@@ -173,6 +184,9 @@ func (c *internalClient) Close() error {
 		)
 		close(c.done)
 		close(c.quit)
+		c.mu.Lock()
+		c.pumpCancel()
+		c.mu.Unlock()
 	})
 	c.goroutineWaitGroup.Wait()
 	return nil
@@ -183,8 +197,8 @@ func (c *internalClient) Done() <-chan struct{} { return c.done }
 
 // ── internal ──────────────────────────────────────────────────────────────────
 
-func (c *internalClient) dialOnce() error {
-	transport, err := c.dialer.Dial(c.url, c.config.dialHeaders)
+func (c *internalClient) dialOnce(ctx context.Context) error {
+	transport, err := c.dialer.Dial(ctx, c.url, c.config.dialHeaders)
 	if err != nil {
 		return err
 	}
@@ -194,7 +208,7 @@ func (c *internalClient) dialOnce() error {
 	return nil
 }
 
-func (c *internalClient) readPump(wsConnection wspulse.Transport, dropped chan struct{}, writeErrCh <-chan error) {
+func (c *internalClient) readPump(ctx context.Context, transport wspulse.Transport, dropped chan struct{}, writeErrCh <-chan error) {
 
 	var readErr error
 
@@ -207,7 +221,7 @@ func (c *internalClient) readPump(wsConnection wspulse.Transport, dropped chan s
 		}
 		// Capture any write error BEFORE closing the transport.
 		// If writePump already failed, its error is on the channel.
-		// Reading before Close() prevents a spurious close-induced
+		// Reading before CloseNow() prevents a spurious close-induced
 		// write error from overriding the original readErr.
 		var writeErr error
 		select {
@@ -215,7 +229,7 @@ func (c *internalClient) readPump(wsConnection wspulse.Transport, dropped chan s
 		default:
 		}
 
-		_ = wsConnection.Close()
+		_ = transport.CloseNow()
 
 		// Determine the root-cause error for onTransportDrop:
 		//   1. User-initiated close → nil (behaviour contract).
@@ -241,17 +255,12 @@ func (c *internalClient) readPump(wsConnection wspulse.Transport, dropped chan s
 		close(dropped)
 	}()
 
-	pongWait := c.config.pongWait
 	if c.config.maxMessageSize > 0 {
-		wsConnection.SetReadLimit(c.config.maxMessageSize)
+		transport.SetReadLimit(c.config.maxMessageSize)
 	}
-	_ = wsConnection.SetReadDeadline(time.Now().Add(pongWait))
-	wsConnection.SetPongHandler(func(string) error {
-		return wsConnection.SetReadDeadline(time.Now().Add(pongWait))
-	})
 
 	for {
-		_, data, err := wsConnection.ReadMessage()
+		_, data, err := transport.Read(ctx)
 		if err != nil {
 			readErr = err
 			return
@@ -269,22 +278,10 @@ func (c *internalClient) readPump(wsConnection wspulse.Transport, dropped chan s
 	}
 }
 
-func (c *internalClient) writePump(wsConnection wspulse.Transport, connectionQuit chan struct{}, pumpDone chan struct{}, writeErrCh chan<- error) {
+func (c *internalClient) writePump(ctx context.Context, transport wspulse.Transport, pumpDone chan struct{}, writeErrCh chan<- error) {
 
-	writeWait := c.config.writeWait
-	pingPeriod := c.config.pingPeriod
-
-	sendClose := func() {
-		_ = wsConnection.SetWriteDeadline(time.Now().Add(writeWait))
-		_ = wsConnection.WriteMessage(websocket.CloseMessage,
-			websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""),
-		)
-	}
-
-	ticker := c.clock.NewTicker(pingPeriod)
 	defer func() {
-		ticker.Stop()
-		_ = wsConnection.Close()
+		_ = transport.CloseNow()
 		close(pumpDone)
 	}()
 
@@ -292,8 +289,8 @@ func (c *internalClient) writePump(wsConnection wspulse.Transport, connectionQui
 		// Reconnect priority check — yield immediately so the new
 		// writePump can take over on a fresh connection.
 		select {
-		case <-connectionQuit:
-			c.logger.Debug("wspulse: writePump yielding for reconnect (priority)")
+		case <-ctx.Done():
+			c.closeOrForce(transport)
 			return
 		default:
 		}
@@ -302,15 +299,17 @@ func (c *internalClient) writePump(wsConnection wspulse.Transport, connectionQui
 		select {
 		case <-c.done:
 			c.logger.Debug("wspulse: writePump stopping (client closed)")
-			sendClose()
+			_ = transport.Close(wspulse.StatusNormalClosure, "")
 			return
 		default:
 		}
 
 		select {
 		case data := <-c.send:
-			_ = wsConnection.SetWriteDeadline(time.Now().Add(writeWait))
-			if err := wsConnection.WriteMessage(c.config.codec.FrameType(), data); err != nil {
+			writeCtx, cancel := context.WithTimeout(ctx, c.config.writeTimeout)
+			err := transport.Write(writeCtx, c.config.codec.FrameType(), data)
+			cancel()
+			if err != nil {
 				c.logger.Warn("wspulse: write failed",
 					zap.Error(err),
 				)
@@ -321,29 +320,67 @@ func (c *internalClient) writePump(wsConnection wspulse.Transport, connectionQui
 				return
 			}
 
-		case <-ticker.C:
-			_ = wsConnection.SetWriteDeadline(time.Now().Add(writeWait))
-			if err := wsConnection.WriteMessage(websocket.PingMessage, nil); err != nil {
-				c.logger.Warn("wspulse: ping write failed",
-					zap.Error(err),
-				)
-				select {
-				case writeErrCh <- err:
-				default:
-				}
-				return
-			}
-
 		case <-c.done:
 			c.logger.Debug("wspulse: writePump stopping (client closed)")
-			sendClose()
+			_ = transport.Close(wspulse.StatusNormalClosure, "")
 			return
 
-		case <-connectionQuit:
-			c.logger.Debug("wspulse: writePump yielding for reconnect")
+		case <-ctx.Done():
+			c.closeOrForce(transport)
 			return
 		}
 	}
+}
+
+// closeOrForce sends a close frame if the client is shutting down, or
+// force-closes if yielding for reconnect.
+func (c *internalClient) closeOrForce(transport wspulse.Transport) {
+	select {
+	case <-c.done:
+		c.logger.Debug("wspulse: writePump stopping (client closed)")
+		_ = transport.Close(wspulse.StatusNormalClosure, "")
+	default:
+		c.logger.Debug("wspulse: writePump yielding for reconnect")
+	}
+}
+
+func (c *internalClient) pingPump(ctx context.Context, transport wspulse.Transport) {
+	ticker := c.clock.NewTicker(c.config.pingInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			if err := c.doPing(ctx, transport); err != nil {
+				return
+			}
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+// doPing sends a ping and waits for the pong within writeTimeout.
+// If the parent context is cancelled (reconnect or close), returns
+// without logging or killing the transport — that is a normal exit.
+// If the pong times out, force-closes the transport so readPump detects
+// the error.
+func (c *internalClient) doPing(ctx context.Context, transport wspulse.Transport) error {
+	pingCtx, cancel := context.WithTimeout(ctx, c.config.writeTimeout)
+	defer cancel()
+	if err := transport.Ping(pingCtx); err != nil {
+		// Parent context cancelled — normal shutdown or reconnect.
+		if ctx.Err() != nil {
+			return err
+		}
+		// Pong timeout — force-close the transport to trigger readPump error.
+		c.logger.Warn("wspulse: pong timeout, closing transport",
+			zap.Error(err),
+		)
+		_ = transport.CloseNow()
+		return err
+	}
+	return nil
 }
 
 func (c *internalClient) reconnectLoop(dropped chan struct{}) {
@@ -371,6 +408,9 @@ func (c *internalClient) reconnectLoop(dropped chan struct{}) {
 			c.once.Do(func() {
 				close(c.done)
 				close(c.quit)
+				c.mu.Lock()
+				c.pumpCancel()
+				c.mu.Unlock()
 			})
 			return
 		}
@@ -392,7 +432,7 @@ func (c *internalClient) reconnectLoop(dropped chan struct{}) {
 			zap.Int("attempt", attempt),
 			zap.String("url", c.url),
 		)
-		if err := c.dialOnce(); err != nil {
+		if err := c.dialOnce(context.Background()); err != nil {
 			c.logger.Debug("wspulse: dial failed",
 				zap.Int("attempt", attempt),
 				zap.Error(err),
@@ -407,43 +447,51 @@ func (c *internalClient) reconnectLoop(dropped chan struct{}) {
 		case <-c.quit:
 			c.logger.Debug("wspulse: quit during dial, closing fresh connection")
 			c.mu.Lock()
-			_ = c.connection.Close()
+			_ = c.connection.CloseNow()
 			c.mu.Unlock()
 			return
 		default:
 		}
 
 		dropped = make(chan struct{})
+
+		// Cancel old pumps and wait for writePump to exit.
 		c.mu.Lock()
-		oldQuit := c.connectionQuit
+		c.pumpCancel()
 		oldPumpDone := c.pumpDone
-		newQuit := make(chan struct{})
-		newPumpDone := make(chan struct{})
-		c.connectionQuit = newQuit
-		c.pumpDone = newPumpDone
-		conn := c.connection
 		c.mu.Unlock()
 
-		close(oldQuit)
 		<-oldPumpDone
 
 		// Guard: if Close() was called while we were waiting for the old
 		// pumps to drain, skip launching new ones to avoid wasted work.
 		// Note: a panic from Add-concurrent-with-Wait is impossible here
 		// because reconnectLoop itself holds one WaitGroup count, keeping
-		// the counter ≥ 1 until this function returns.
+		// the counter >= 1 until this function returns.
 		select {
 		case <-c.quit:
 			c.logger.Debug("wspulse: quit before starting fresh pumps, closing fresh connection")
-			_ = conn.Close()
+			c.mu.Lock()
+			_ = c.connection.CloseNow()
+			c.mu.Unlock()
 			return
 		default:
 		}
 
+		newPumpCtx, newPumpCancel := context.WithCancel(context.Background())
+		newPumpDone := make(chan struct{})
 		newWriteErrCh := make(chan error, 1)
-		c.goroutineWaitGroup.Add(2)
-		go func() { defer c.goroutineWaitGroup.Done(); c.writePump(conn, newQuit, newPumpDone, newWriteErrCh) }()
-		go func() { defer c.goroutineWaitGroup.Done(); c.readPump(conn, dropped, newWriteErrCh) }()
+
+		c.mu.Lock()
+		c.pumpCancel = newPumpCancel
+		c.pumpDone = newPumpDone
+		conn := c.connection
+		c.mu.Unlock()
+
+		c.goroutineWaitGroup.Add(3)
+		go func() { defer c.goroutineWaitGroup.Done(); c.readPump(newPumpCtx, conn, dropped, newWriteErrCh) }()
+		go func() { defer c.goroutineWaitGroup.Done(); c.writePump(newPumpCtx, conn, newPumpDone, newWriteErrCh) }()
+		go func() { defer c.goroutineWaitGroup.Done(); c.pingPump(newPumpCtx, conn) }()
 		c.logger.Info("wspulse: reconnected",
 			zap.Int("attempt", attempt),
 			zap.String("url", c.url),
@@ -457,7 +505,7 @@ func (c *internalClient) reconnectLoop(dropped chan struct{}) {
 
 // normalizeScheme converts http/https URL schemes to their WebSocket
 // equivalents (http → ws, https → wss). All other URLs are returned
-// unchanged — gorilla/websocket already validates schemes at dial
+// unchanged — the underlying WebSocket dialer validates schemes at dial
 // time and returns a catchable error, so we avoid duplicating that.
 func normalizeScheme(rawURL string) string {
 	if len(rawURL) < 8 {

--- a/client.go
+++ b/client.go
@@ -301,7 +301,7 @@ func (c *internalClient) writePump(ctx context.Context, transport wspulse.Transp
 		select {
 		case <-c.done:
 			c.logger.Debug("wspulse: writePump stopping (client closed)")
-			_ = transport.Close(wspulse.StatusNormalClosure, "")
+			c.gracefulClose(transport)
 			return
 		default:
 		}
@@ -324,7 +324,7 @@ func (c *internalClient) writePump(ctx context.Context, transport wspulse.Transp
 
 		case <-c.done:
 			c.logger.Debug("wspulse: writePump stopping (client closed)")
-			_ = transport.Close(wspulse.StatusNormalClosure, "")
+			c.gracefulClose(transport)
 			return
 
 		case <-ctx.Done():
@@ -335,14 +335,34 @@ func (c *internalClient) writePump(ctx context.Context, transport wspulse.Transp
 }
 
 // closeOrForce sends a close frame if the client is shutting down, or
-// force-closes if yielding for reconnect.
+// returns immediately if yielding for reconnect. In both cases the
+// deferred CloseNow() in writePump guarantees the transport is released.
 func (c *internalClient) closeOrForce(transport wspulse.Transport) {
 	select {
 	case <-c.done:
 		c.logger.Debug("wspulse: writePump stopping (client closed)")
-		_ = transport.Close(wspulse.StatusNormalClosure, "")
+		c.gracefulClose(transport)
 	default:
 		c.logger.Debug("wspulse: writePump yielding for reconnect")
+	}
+}
+
+// gracefulClose attempts to send a WebSocket close frame within
+// writeTimeout. If the transport blocks (e.g. dead peer), CloseNow
+// is called as a fallback to prevent hanging.
+func (c *internalClient) gracefulClose(transport wspulse.Transport) {
+	done := make(chan struct{})
+	go func() {
+		_ = transport.Close(wspulse.StatusNormalClosure, "")
+		close(done)
+	}()
+	t := time.NewTimer(c.config.writeTimeout)
+	defer t.Stop()
+	select {
+	case <-done:
+	case <-t.C:
+		c.logger.Warn("wspulse: close frame timed out, forcing close")
+		_ = transport.CloseNow()
 	}
 }
 

--- a/client_test.go
+++ b/client_test.go
@@ -64,26 +64,41 @@ func TestClient_WithCodec_Nil_Panics(t *testing.T) {
 	})
 }
 
-func TestClient_WithHeartbeat_InvalidParams_Panics(t *testing.T) {
+func TestClient_WithPingInterval_InvalidParams_Panics(t *testing.T) {
 	t.Parallel()
 	cases := []struct {
-		name               string
-		ping, pong, writeW time.Duration
-		wantMsg            string
+		name    string
+		d       time.Duration
+		wantMsg string
 	}{
-		{"ping zero", 0, 10 * time.Second, 5 * time.Second, "wspulse: heartbeat.pingPeriod must be positive"},
-		{"pong zero", 5 * time.Second, 0, 5 * time.Second, "wspulse: heartbeat.pongWait must be positive"},
-		{"writeWait zero", 5 * time.Second, 10 * time.Second, 0, "wspulse: writeWait must be positive"},
-		{"ping == pong", 10 * time.Second, 10 * time.Second, 5 * time.Second, "wspulse: heartbeat.pingPeriod must be strictly less than heartbeat.pongWait"},
-		{"ping > pong", 30 * time.Second, 10 * time.Second, 5 * time.Second, "wspulse: heartbeat.pingPeriod must be strictly less than heartbeat.pongWait"},
-		{"ping exceeds max", 2 * time.Minute, 3 * time.Minute, 5 * time.Second, "wspulse: heartbeat.pingPeriod exceeds maximum (1m)"},
-		{"pong exceeds max", 1 * time.Second, 3 * time.Minute, 5 * time.Second, "wspulse: heartbeat.pongWait exceeds maximum (2m)"},
-		{"writeWait exceeds max", 1 * time.Second, 5 * time.Second, 31 * time.Second, "wspulse: writeWait exceeds maximum (30s)"},
+		{"zero", 0, "wspulse: pingInterval must be positive"},
+		{"negative", -1 * time.Second, "wspulse: pingInterval must be positive"},
+		{"exceeds max", 2 * time.Minute, "wspulse: pingInterval exceeds maximum (1m)"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			require.PanicsWithValue(t, tc.wantMsg, func() {
-				_ = client.WithHeartbeat(tc.ping, tc.pong, tc.writeW)
+				_ = client.WithPingInterval(tc.d)
+			})
+		})
+	}
+}
+
+func TestClient_WithWriteTimeout_InvalidParams_Panics(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name    string
+		d       time.Duration
+		wantMsg string
+	}{
+		{"zero", 0, "wspulse: writeTimeout must be positive"},
+		{"negative", -1 * time.Second, "wspulse: writeTimeout must be positive"},
+		{"exceeds max", 31 * time.Second, "wspulse: writeTimeout exceeds maximum (30s)"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.PanicsWithValue(t, tc.wantMsg, func() {
+				_ = client.WithWriteTimeout(tc.d)
 			})
 		})
 	}
@@ -252,19 +267,37 @@ func TestClient_WithMaxMessageSize_BoundaryValues(t *testing.T) {
 	}
 }
 
-func TestClient_WithHeartbeat_ValidParams_NoPanic(t *testing.T) {
+func TestClient_WithPingInterval_ValidParams_NoPanic(t *testing.T) {
 	t.Parallel()
 	cases := []struct {
-		name               string
-		ping, pong, writeW time.Duration
+		name string
+		d    time.Duration
 	}{
-		{"typical", 20 * time.Second, 60 * time.Second, 10 * time.Second},
-		{"minimum gap", 1 * time.Millisecond, 2 * time.Millisecond, 1 * time.Millisecond},
-		{"max boundary", 1 * time.Minute, 2 * time.Minute, 30 * time.Second},
+		{"minimum", 1 * time.Millisecond},
+		{"typical", 20 * time.Second},
+		{"maximum", 1 * time.Minute},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			opt := client.WithHeartbeat(tc.ping, tc.pong, tc.writeW)
+			opt := client.WithPingInterval(tc.d)
+			assert.NotNil(t, opt)
+		})
+	}
+}
+
+func TestClient_WithWriteTimeout_ValidParams_NoPanic(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		d    time.Duration
+	}{
+		{"minimum", 1 * time.Millisecond},
+		{"typical", 10 * time.Second},
+		{"maximum", 30 * time.Second},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			opt := client.WithWriteTimeout(tc.d)
 			assert.NotNil(t, opt)
 		})
 	}

--- a/dialer.go
+++ b/dialer.go
@@ -1,25 +1,28 @@
 package client
 
 import (
+	"context"
 	"net/http"
 
-	"github.com/gorilla/websocket"
+	"github.com/coder/websocket"
 
 	wspulse "github.com/wspulse/core"
 )
 
 // dialer abstracts the WebSocket dial operation for testability.
 type dialer interface {
-	Dial(url string, requestHeader http.Header) (wspulse.Transport, error)
+	Dial(ctx context.Context, url string, requestHeader http.Header) (wspulse.Transport, error)
 }
 
-// gorillaDialer uses gorilla/websocket.DefaultDialer.
-type gorillaDialer struct{}
+// coderDialer uses github.com/coder/websocket.
+type coderDialer struct{}
 
-func (gorillaDialer) Dial(url string, requestHeader http.Header) (wspulse.Transport, error) {
-	conn, resp, err := websocket.DefaultDialer.Dial(url, requestHeader)
-	if resp != nil && resp.Body != nil {
-		_ = resp.Body.Close()
+func (coderDialer) Dial(ctx context.Context, url string, requestHeader http.Header) (wspulse.Transport, error) {
+	conn, _, err := websocket.Dial(ctx, url, &websocket.DialOptions{
+		HTTPHeader: requestHeader,
+	})
+	if err != nil {
+		return nil, err
 	}
-	return conn, err
+	return &coderTransport{conn: conn}, nil
 }

--- a/doc/component-tests.md
+++ b/doc/component-tests.md
@@ -78,8 +78,9 @@ deterministic and run with `make check`.
 | `TestWithDialHeaders`                              | Custom dial headers are forwarded to the dialer               |
 | `TestWithMaxMessageSize`                           | `SetReadLimit` is called with configured size                 |
 | `TestWithMaxMessageSize_OversizedMessage`          | Oversized message triggers read error                         |
-| `TestWithHeartbeat_ValidParams_Applied`            | `WithHeartbeat` option is accepted                            |
-| `TestWithHeartbeat_SendsPings`                     | Ping messages are sent at configured interval                 |
+| `TestPingInterval_SendsPings`                      | Ping messages are sent at configured interval                 |
+| `TestPongTimeout_DisconnectsClient`                | Pong timeout force-closes transport                           |
+| `TestWithPingInterval_ValidParams_Applied`         | `WithPingInterval` option is accepted                         |
 | `TestWithLogger_ValidLogger_Applied`               | `WithLogger` option is accepted                               |
 
-**Total: 41 component tests** (9 contract scenarios + additional per-feature tests).
+**Total: 42 component tests** (9 contract scenarios + additional per-feature tests).

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/wspulse/client-go
 go 1.26.0
 
 require (
-	github.com/gorilla/websocket v1.5.3
+	github.com/coder/websocket v1.8.14
 	github.com/stretchr/testify v1.11.1
 	github.com/wspulse/core v0.3.1
 	go.uber.org/goleak v1.3.0

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.26.0
 require (
 	github.com/coder/websocket v1.8.14
 	github.com/stretchr/testify v1.11.1
-	github.com/wspulse/core v0.3.1
+	github.com/wspulse/core v0.4.0
 	go.uber.org/goleak v1.3.0
 	go.uber.org/zap v1.27.1
 )

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
+github.com/coder/websocket v1.8.14 h1:9L0p0iKiNOibykf283eHkKUHHrpG7f65OE3BhhO7v9g=
+github.com/coder/websocket v1.8.14/go.mod h1:NX3SzP+inril6yawo5CQXx8+fk145lPDC6pumgx0mVg=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
-github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=

--- a/go.sum
+++ b/go.sum
@@ -10,8 +10,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
-github.com/wspulse/core v0.3.1 h1:IPcFmNoX9or0rCqr7sRuDTfxLU8X+9bXoonlxVG4hFM=
-github.com/wspulse/core v0.3.1/go.mod h1:ZJxv16MeEIcq9z3Wo2fmz3P+qSz3IA28nuoTYk8pYC0=
+github.com/wspulse/core v0.4.0 h1:ZYQSGPu1invHlD2iIfzqeHWu4eck6eBGqH4PCdFSIsk=
+github.com/wspulse/core v0.4.0/go.mod h1:ZJxv16MeEIcq9z3Wo2fmz3P+qSz3IA28nuoTYk8pYC0=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
 go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
 go.uber.org/multierr v1.10.0 h1:S0h4aNzvfcFsC3dRF1jLoaov7oRaKqRGC/pUEJ2yvPQ=

--- a/misc_test.go
+++ b/misc_test.go
@@ -1,6 +1,7 @@
 package client_test
 
 import (
+	"context"
 	"errors"
 	"net"
 	"net/http"
@@ -71,10 +72,10 @@ func TestReadPump_DecodeFailure_DropsFrame(t *testing.T) {
 	t.Cleanup(func() { _ = c.Close() })
 
 	// Inject an invalid JSON frame (decode failure — should be dropped).
-	mt.InjectMessage(1, []byte("not valid json{{{"))
+	mt.InjectMessage(wspulse.TextMessage, []byte("not valid json{{{"))
 	// Inject a valid frame that should be delivered.
 	validFrame := `{"event":"valid-frame","payload":"ok"}`
-	mt.InjectMessage(1, []byte(validFrame))
+	mt.InjectMessage(wspulse.TextMessage, []byte(validFrame))
 
 	f := requireReceive(t, received)
 	assert.Equal(t, "valid-frame", f.Event)
@@ -95,7 +96,7 @@ func TestReadPump_PanicRecovery(t *testing.T) {
 
 	// Inject a valid frame to trigger the panic in OnMessage.
 	trigger := `{"event":"trigger","payload":null}`
-	mt.InjectMessage(1, []byte(trigger))
+	mt.InjectMessage(wspulse.TextMessage, []byte(trigger))
 
 	_ = requireReceive(t, disconnected)
 }
@@ -118,12 +119,40 @@ func TestSend_EncodeError_ReturnsError(t *testing.T) {
 	require.Error(t, err, "expected encode error")
 }
 
+func TestPingInterval_SendsPings(t *testing.T) {
+	t.Parallel()
+	// Verify that with a fake clock, firing the heartbeat ticker causes a ping.
+	mt := newMockTransport()
+	mt.pingCh = make(chan struct{}, 16)
+	fc := newFakeClock()
+	md := newMockDialer(mockDialResult{transport: mt})
+
+	c, err := client.Dial("ws://mock",
+		client.WithDialer(md),
+		client.WithClock(fc),
+		client.WithPingInterval(50*time.Millisecond),
+		client.WithWriteTimeout(5*time.Second),
+	)
+	require.NoError(t, err, "Dial failed")
+	t.Cleanup(func() { _ = c.Close() })
+
+	// Wait for pingPump to create the heartbeat ticker.
+	requireReceive(t, fc.tickerAdded)
+
+	// Fire the ticker to trigger a ping.
+	fc.fireTicker(0)
+
+	// Verify ping was called.
+	requireReceive(t, mt.pingCh)
+	fc.stopTicker(0)
+}
+
 func TestHeartbeat_ReadError_DisconnectsClient(t *testing.T) {
 	t.Parallel()
 	// Verifies the observable heartbeat behaviour: the client sends pings
 	// via the heartbeat ticker, and when the transport dies the client disconnects.
-	// We use a fake clock so the ticker fires only when the test drives it.
 	mt := newMockTransport()
+	mt.pingCh = make(chan struct{}, 16)
 	fc := newFakeClock()
 	md := newMockDialer(mockDialResult{transport: mt})
 
@@ -131,7 +160,8 @@ func TestHeartbeat_ReadError_DisconnectsClient(t *testing.T) {
 	c, err := client.Dial("ws://mock",
 		client.WithDialer(md),
 		client.WithClock(fc),
-		client.WithHeartbeat(50*time.Millisecond, 150*time.Millisecond, 10*time.Second),
+		client.WithPingInterval(50*time.Millisecond),
+		client.WithWriteTimeout(10*time.Second),
 		client.WithOnDisconnect(func(err error) {
 			disconnected <- err
 		}),
@@ -139,22 +169,14 @@ func TestHeartbeat_ReadError_DisconnectsClient(t *testing.T) {
 	require.NoError(t, err, "Dial failed")
 	t.Cleanup(func() { _ = c.Close() })
 
-	// Wait for writePump to create the heartbeat ticker.
+	// Wait for pingPump to create the heartbeat ticker.
 	requireReceive(t, fc.tickerAdded)
 
-	// Fire the ticker to trigger a ping write.
+	// Fire the ticker to trigger a ping.
 	fc.fireTicker(0)
 
-	// Verify a ping was written.
-	pingSeen := false
-	for {
-		w := requireReceive(t, mt.writeCh)
-		if w.messageType == 9 { // PingMessage
-			pingSeen = true
-			break
-		}
-	}
-	require.True(t, pingSeen, "no ping message observed")
+	// Verify a ping was sent.
+	requireReceive(t, mt.pingCh)
 	fc.stopTicker(0)
 
 	// Kill the transport to simulate a connection loss.
@@ -164,6 +186,42 @@ func TestHeartbeat_ReadError_DisconnectsClient(t *testing.T) {
 	assert.Error(t, got, "want non-nil error on disconnect")
 
 	requireDone(t, c)
+}
+
+func TestPongTimeout_DisconnectsClient(t *testing.T) {
+	t.Parallel()
+	// When the server never responds to a ping, the writeTimeout context
+	// expires and pingPump force-closes the transport.
+	mt := newMockTransport()
+	mt.pingFunc = func(ctx context.Context) error {
+		<-ctx.Done()
+		return ctx.Err()
+	}
+	fc := newFakeClock()
+	md := newMockDialer(mockDialResult{transport: mt})
+
+	transportDropped := make(chan error, 1)
+	c, err := client.Dial("ws://mock",
+		client.WithDialer(md),
+		client.WithClock(fc),
+		client.WithPingInterval(50*time.Millisecond),
+		client.WithWriteTimeout(50*time.Millisecond),
+		client.WithOnTransportDrop(func(err error) {
+			transportDropped <- err
+		}),
+	)
+	require.NoError(t, err, "Dial failed")
+	t.Cleanup(func() { _ = c.Close() })
+
+	// Wait for pingPump to create the ticker.
+	requireReceive(t, fc.tickerAdded)
+
+	// Fire the ticker — ping blocks, writeTimeout expires, CloseNow fires.
+	fc.fireTicker(0)
+
+	got := requireReceive(t, transportDropped)
+	assert.Error(t, got, "want non-nil error on pong timeout")
+	fc.stopTicker(0)
 }
 
 func TestWithDialHeaders(t *testing.T) {
@@ -256,7 +314,7 @@ func TestWithMaxMessageSize_OversizedMessage(t *testing.T) {
 	mt.mu.Unlock()
 	assert.Equal(t, int64(10), readLimit, "SetReadLimit")
 
-	// Simulate what the real gorilla transport would do: return an error
+	// Simulate what the real transport would do: return an error
 	// when receiving an oversized message.
 	mt.InjectError(errors.New("websocket: read limit exceeded"))
 
@@ -272,46 +330,11 @@ func TestWithLogger_ValidLogger_Applied(t *testing.T) {
 	_ = c.Close()
 }
 
-func TestWithHeartbeat_ValidParams_Applied(t *testing.T) {
+func TestWithPingInterval_ValidParams_Applied(t *testing.T) {
 	t.Parallel()
-	// WithHeartbeat is applied at option construction time. Verify the client
-	// can be created and closed with custom heartbeat params.
 	c, _, _ := dialWithMock(t,
-		client.WithHeartbeat(5*time.Second, 15*time.Second, 3*time.Second),
+		client.WithPingInterval(5*time.Second),
+		client.WithWriteTimeout(3*time.Second),
 	)
 	_ = c.Close()
-}
-
-func TestWithHeartbeat_SendsPings(t *testing.T) {
-	t.Parallel()
-	// Verify that with a fake clock, firing the heartbeat ticker causes a ping.
-	mt := newMockTransport()
-	fc := newFakeClock()
-	md := newMockDialer(mockDialResult{transport: mt})
-
-	c, err := client.Dial("ws://mock",
-		client.WithDialer(md),
-		client.WithClock(fc),
-		client.WithHeartbeat(50*time.Millisecond, 200*time.Millisecond, 5*time.Second),
-	)
-	require.NoError(t, err, "Dial failed")
-	t.Cleanup(func() { _ = c.Close() })
-
-	// Wait for writePump to create the heartbeat ticker.
-	requireReceive(t, fc.tickerAdded)
-
-	// Fire the ticker to trigger a ping write.
-	fc.fireTicker(0)
-
-	// Read writes until we see a ping.
-	pingSeen := false
-	for {
-		w := requireReceive(t, mt.writeCh)
-		if w.messageType == 9 { // PingMessage
-			pingSeen = true
-			break
-		}
-	}
-	require.True(t, pingSeen, "no ping message received from heartbeat")
-	fc.stopTicker(0)
 }

--- a/mock_transport_test.go
+++ b/mock_transport_test.go
@@ -1,11 +1,11 @@
 package client_test
 
 import (
+	"context"
 	"errors"
 	"net"
 	"net/http"
 	"sync"
-	"time"
 
 	wspulse "github.com/wspulse/core"
 
@@ -20,27 +20,34 @@ type mockTransport struct {
 	writeCh   chan writeCall
 	closeCh   chan struct{}
 	closeOnce sync.Once
-	blockCh   chan struct{} // when non-nil, WriteMessage blocks until blockCh or closeCh is closed
+	blockCh   chan struct{} // when non-nil, Write blocks until blockCh or closeCh is closed
 
 	mu           sync.Mutex
 	readLimit    int64
-	readLimitSet chan struct{} // signaled once when SetReadLimit is first called with a non-zero value
-	writeEntered chan struct{} // when non-nil, signaled each time WriteMessage is entered (before blocking)
-	pongHandler  func(string) error
-	writeErr     error  // when non-nil, WriteMessage returns this error immediately
-	closeHook    func() // when non-nil, runs inside Close() after closeCh is closed but before Close() returns
+	readLimitSet chan struct{}                   // signaled once when SetReadLimit is first called with a non-zero value
+	writeEntered chan struct{}                   // when non-nil, signaled each time Write is entered (before blocking)
+	pingCh       chan struct{}                   // when non-nil, signaled each time Ping is called
+	pingFunc     func(ctx context.Context) error // when non-nil, Ping delegates to this function
+	closeCalled  chan closeCall                  // when non-nil, signaled on Close(code, reason)
+	writeErr     error                           // when non-nil, Write returns this error immediately
+	closeHook    func()                          // when non-nil, runs inside doClose after closeCh is closed
 	closed       bool
 }
 
 type readResult struct {
-	messageType int
+	messageType wspulse.MessageType
 	data        []byte
 	err         error
 }
 
 type writeCall struct {
-	messageType int
+	messageType wspulse.MessageType
 	data        []byte
+}
+
+type closeCall struct {
+	code   wspulse.StatusCode
+	reason string
 }
 
 func newMockTransport() *mockTransport {
@@ -52,16 +59,18 @@ func newMockTransport() *mockTransport {
 	}
 }
 
-func (m *mockTransport) ReadMessage() (int, []byte, error) {
+func (m *mockTransport) Read(ctx context.Context) (wspulse.MessageType, []byte, error) {
 	select {
 	case r := <-m.readCh:
 		return r.messageType, r.data, r.err
 	case <-m.closeCh:
 		return 0, nil, &net.OpError{Op: "read", Err: net.ErrClosed}
+	case <-ctx.Done():
+		return 0, nil, ctx.Err()
 	}
 }
 
-func (m *mockTransport) WriteMessage(messageType int, data []byte) error {
+func (m *mockTransport) Write(ctx context.Context, typ wspulse.MessageType, data []byte) error {
 	m.mu.Lock()
 	if m.closed {
 		m.mu.Unlock()
@@ -92,20 +101,40 @@ func (m *mockTransport) WriteMessage(messageType int, data []byte) error {
 			// Unblocked — fall through to normal write path.
 		case <-m.closeCh:
 			return &net.OpError{Op: "write", Err: net.ErrClosed}
+		case <-ctx.Done():
+			return ctx.Err()
 		}
 	}
 
 	copied := make([]byte, len(data))
 	copy(copied, data)
 	select {
-	case m.writeCh <- writeCall{messageType: messageType, data: copied}:
+	case m.writeCh <- writeCall{messageType: typ, data: copied}:
 		return nil
 	case <-m.closeCh:
 		return &net.OpError{Op: "write", Err: net.ErrClosed}
+	case <-ctx.Done():
+		return ctx.Err()
 	default:
 		// Channel full — drop silently. Backpressure tests use blockCh instead.
 		return nil
 	}
+}
+
+func (m *mockTransport) Ping(ctx context.Context) error {
+	if m.pingCh != nil {
+		select {
+		case m.pingCh <- struct{}{}:
+		default:
+		}
+	}
+	m.mu.Lock()
+	fn := m.pingFunc
+	m.mu.Unlock()
+	if fn != nil {
+		return fn(ctx)
+	}
+	return nil
 }
 
 func (m *mockTransport) SetReadLimit(limit int64) {
@@ -120,16 +149,21 @@ func (m *mockTransport) SetReadLimit(limit int64) {
 	}
 }
 
-func (m *mockTransport) SetReadDeadline(_ time.Time) error  { return nil }
-func (m *mockTransport) SetWriteDeadline(_ time.Time) error { return nil }
-
-func (m *mockTransport) SetPongHandler(h func(string) error) {
-	m.mu.Lock()
-	m.pongHandler = h
-	m.mu.Unlock()
+func (m *mockTransport) Close(code wspulse.StatusCode, reason string) error {
+	if m.closeCalled != nil {
+		select {
+		case m.closeCalled <- closeCall{code: code, reason: reason}:
+		default:
+		}
+	}
+	return m.doClose()
 }
 
-func (m *mockTransport) Close() error {
+func (m *mockTransport) CloseNow() error {
+	return m.doClose()
+}
+
+func (m *mockTransport) doClose() error {
 	m.closeOnce.Do(func() {
 		m.mu.Lock()
 		m.closed = true
@@ -143,7 +177,7 @@ func (m *mockTransport) Close() error {
 	return nil
 }
 
-// BlockWrites causes WriteMessage to block until unblock is called or the
+// BlockWrites causes Write to block until unblock is called or the
 // transport is closed. Used by backpressure tests to deterministically stall
 // writePump. The returned function unblocks all pending and future writes.
 func (m *mockTransport) BlockWrites() (unblock func()) {
@@ -162,7 +196,7 @@ func (m *mockTransport) BlockWrites() (unblock func()) {
 	}
 }
 
-// SetWriteError causes all subsequent WriteMessage calls to return err.
+// SetWriteError causes all subsequent Write calls to return err.
 func (m *mockTransport) SetWriteError(err error) {
 	m.mu.Lock()
 	m.writeErr = err
@@ -170,8 +204,8 @@ func (m *mockTransport) SetWriteError(err error) {
 }
 
 // InjectMessage simulates a message from the server.
-func (m *mockTransport) InjectMessage(messageType int, data []byte) {
-	m.readCh <- readResult{messageType: messageType, data: data}
+func (m *mockTransport) InjectMessage(typ wspulse.MessageType, data []byte) {
+	m.readCh <- readResult{messageType: typ, data: data}
 }
 
 // InjectError simulates a read error (e.g. connection drop).
@@ -214,7 +248,7 @@ func newMockDialer(results ...mockDialResult) *mockDialer {
 	}
 }
 
-func (d *mockDialer) Dial(url string, header http.Header) (wspulse.Transport, error) {
+func (d *mockDialer) Dial(_ context.Context, _ string, _ http.Header) (wspulse.Transport, error) {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 	if d.callCount >= len(d.results) {

--- a/options.go
+++ b/options.go
@@ -12,9 +12,8 @@ import (
 
 // Configuration upper bounds — option functions panic if these ceilings are exceeded.
 const (
-	maxPingPeriod    = 1 * time.Minute  // WithHeartbeat: pingPeriod upper bound
-	maxPongWait      = 2 * time.Minute  // WithHeartbeat: pongWait upper bound
-	maxWriteWait     = 30 * time.Second // WithHeartbeat: writeWait upper bound
+	maxPingInterval  = 1 * time.Minute  // WithPingInterval upper bound
+	maxWriteTimeout  = 30 * time.Second // WithWriteTimeout upper bound
 	maxMsgSizeBytes  = 64 << 20         // WithMaxMessageSize upper bound — 64 MiB
 	maxBaseDelay     = 1 * time.Minute  // WithAutoReconnect: baseDelay upper bound
 	maxDelayLimit    = 5 * time.Minute  // WithAutoReconnect: maxDelay upper bound
@@ -37,9 +36,8 @@ type clientConfig struct {
 	maxRetries         int // 0 means retry indefinitely
 	baseDelay          time.Duration
 	maxDelay           time.Duration
-	pongWait           time.Duration
-	pingPeriod         time.Duration
-	writeWait          time.Duration
+	pingInterval       time.Duration
+	writeTimeout       time.Duration
 	maxMessageSize     int64 // max inbound message size in bytes; 0 = no size enforcement
 	sendBufferSize     int   // outbound channel capacity (number of frames)
 	clock              clock
@@ -54,13 +52,12 @@ func defaultClientConfig() *clientConfig {
 		maxRetries:     10,
 		baseDelay:      1 * time.Second,
 		maxDelay:       30 * time.Second,
-		pongWait:       60 * time.Second,
-		pingPeriod:     20 * time.Second,
-		writeWait:      10 * time.Second,
+		pingInterval:   20 * time.Second,
+		writeTimeout:   10 * time.Second,
 		maxMessageSize: 1 << 20, // 1 MiB
 		sendBufferSize: 256,
 		clock:          realClock{},
-		dialer:         gorillaDialer{},
+		dialer:         coderDialer{},
 	}
 }
 
@@ -145,35 +142,29 @@ func WithLogger(logger *zap.Logger) ClientOption {
 	return func(c *clientConfig) { c.logger = logger }
 }
 
-// WithHeartbeat configures client-side Ping/Pong heartbeat intervals.
-// pingPeriod must be in (0, 1m], pongWait in (pingPeriod, 2m], writeWait in (0, 30s].
-func WithHeartbeat(pingPeriod, pongWait, writeWait time.Duration) ClientOption {
-	if pingPeriod <= 0 {
-		panic("wspulse: heartbeat.pingPeriod must be positive")
+// WithPingInterval sets the interval between heartbeat pings.
+// d must be in (0, 1m]. Default is 20s.
+func WithPingInterval(d time.Duration) ClientOption {
+	if d <= 0 {
+		panic("wspulse: pingInterval must be positive")
 	}
-	if pongWait <= 0 {
-		panic("wspulse: heartbeat.pongWait must be positive")
+	if d > maxPingInterval {
+		panic("wspulse: pingInterval exceeds maximum (1m)")
 	}
-	if writeWait <= 0 {
-		panic("wspulse: writeWait must be positive")
+	return func(c *clientConfig) { c.pingInterval = d }
+}
+
+// WithWriteTimeout sets the timeout for all write operations, including
+// ping/pong. Pong must arrive within this duration or the connection is
+// considered dead. d must be in (0, 30s]. Default is 10s.
+func WithWriteTimeout(d time.Duration) ClientOption {
+	if d <= 0 {
+		panic("wspulse: writeTimeout must be positive")
 	}
-	if pingPeriod >= pongWait {
-		panic("wspulse: heartbeat.pingPeriod must be strictly less than heartbeat.pongWait")
+	if d > maxWriteTimeout {
+		panic("wspulse: writeTimeout exceeds maximum (30s)")
 	}
-	if pingPeriod > maxPingPeriod {
-		panic("wspulse: heartbeat.pingPeriod exceeds maximum (1m)")
-	}
-	if pongWait > maxPongWait {
-		panic("wspulse: heartbeat.pongWait exceeds maximum (2m)")
-	}
-	if writeWait > maxWriteWait {
-		panic("wspulse: writeWait exceeds maximum (30s)")
-	}
-	return func(c *clientConfig) {
-		c.pingPeriod = pingPeriod
-		c.pongWait = pongWait
-		c.writeWait = writeWait
-	}
+	return func(c *clientConfig) { c.writeTimeout = d }
 }
 
 // WithSendBufferSize sets the outbound channel capacity (number of frames).

--- a/options.go
+++ b/options.go
@@ -154,9 +154,9 @@ func WithPingInterval(d time.Duration) ClientOption {
 	return func(c *clientConfig) { c.pingInterval = d }
 }
 
-// WithWriteTimeout sets the timeout for all write operations, including
-// ping/pong. Pong must arrive within this duration or the connection is
-// considered dead. d must be in (0, 30s]. Default is 10s.
+// WithWriteTimeout sets the timeout for all write operations: data frames,
+// ping/pong, and the close handshake. Pong must arrive within this duration
+// or the connection is considered dead. d must be in (0, 30s]. Default is 10s.
 func WithWriteTimeout(d time.Duration) ClientOption {
 	if d <= 0 {
 		panic("wspulse: writeTimeout must be positive")

--- a/testhelpers_test.go
+++ b/testhelpers_test.go
@@ -1,6 +1,7 @@
 package client_test
 
 import (
+	"context"
 	"errors"
 	"net/http"
 	"sync"
@@ -84,7 +85,7 @@ func (fc *fakeClock) TickerCount() int {
 }
 
 // fireTicker fires the i-th registered ticker by resetting it to 1ns.
-// The consumer (writePump) reads from ticker.C and acts on the tick.
+// The consumer (pingPump) reads from ticker.C and acts on the tick.
 // Call stopTicker(i) after verifying the side effect to prevent repeated ticks.
 func (fc *fakeClock) fireTicker(i int) {
 	fc.mu.Lock()
@@ -109,9 +110,9 @@ func echoLoop(mt *mockTransport, done chan struct{}) {
 	for {
 		select {
 		case w := <-mt.writeCh:
-			// Only echo text messages (type 1), skip pings (9) and close (8).
-			if w.messageType == 1 {
-				mt.InjectMessage(1, w.data)
+			// Only echo text messages, skip others.
+			if w.messageType == wspulse.TextMessage {
+				mt.InjectMessage(wspulse.TextMessage, w.data)
 			}
 		case <-done:
 			return
@@ -168,7 +169,7 @@ type headerCapturingDialer struct {
 	called    atomic.Bool
 }
 
-func (d *headerCapturingDialer) Dial(_ string, header http.Header) (wspulse.Transport, error) {
+func (d *headerCapturingDialer) Dial(_ context.Context, _ string, header http.Header) (wspulse.Transport, error) {
 	if d.onDial != nil {
 		d.onDial(header)
 	}
@@ -202,4 +203,4 @@ func (failEncodeCodecComponent) Decode(data []byte) (wspulse.Frame, error) {
 	return wspulse.Frame{}, nil
 }
 
-func (failEncodeCodecComponent) FrameType() int { return 1 }
+func (failEncodeCodecComponent) FrameType() wspulse.MessageType { return wspulse.TextMessage }

--- a/transport.go
+++ b/transport.go
@@ -1,0 +1,41 @@
+package client
+
+import (
+	"context"
+
+	"github.com/coder/websocket"
+
+	wspulse "github.com/wspulse/core"
+)
+
+// coderTransport wraps *websocket.Conn to satisfy core.Transport.
+// All type conversions are simple casts — numeric values are identical
+// between coder/websocket and wspulse/core (both follow RFC 6455).
+type coderTransport struct {
+	conn *websocket.Conn
+}
+
+func (t *coderTransport) Read(ctx context.Context) (wspulse.MessageType, []byte, error) {
+	typ, data, err := t.conn.Read(ctx)
+	return wspulse.MessageType(typ), data, err
+}
+
+func (t *coderTransport) Write(ctx context.Context, typ wspulse.MessageType, data []byte) error {
+	return t.conn.Write(ctx, websocket.MessageType(typ), data)
+}
+
+func (t *coderTransport) Ping(ctx context.Context) error {
+	return t.conn.Ping(ctx)
+}
+
+func (t *coderTransport) SetReadLimit(n int64) {
+	t.conn.SetReadLimit(n)
+}
+
+func (t *coderTransport) Close(code wspulse.StatusCode, reason string) error {
+	return t.conn.Close(websocket.StatusCode(code), reason)
+}
+
+func (t *coderTransport) CloseNow() error {
+	return t.conn.CloseNow()
+}

--- a/transport.go
+++ b/transport.go
@@ -8,6 +8,12 @@ import (
 	wspulse "github.com/wspulse/core"
 )
 
+// Compile-time assertions: numeric values must match between coder/websocket
+// and wspulse/core (both follow RFC 6455). A mismatch here means frames
+// would be silently mis-typed at runtime.
+var _ = [1]struct{}{}[websocket.MessageText-websocket.MessageType(wspulse.TextMessage)]
+var _ = [1]struct{}{}[websocket.MessageBinary-websocket.MessageType(wspulse.BinaryMessage)]
+
 // coderTransport wraps *websocket.Conn to satisfy core.Transport.
 // All type conversions are simple casts — numeric values are identical
 // between coder/websocket and wspulse/core (both follow RFC 6455).


### PR DESCRIPTION
## Summary

Migrate the WebSocket transport from `gorilla/websocket` (archived, unmaintained) to `coder/websocket` (actively maintained, context-native), and restructure the heartbeat architecture from 2-pump to 3-pump. This is a breaking change — `WithHeartbeat` is replaced by `WithPingInterval` + `WithWriteTimeout`.

## Related issues

Closes #35
Relates to wspulse/.github#32

## Changes

- Add `coderTransport` adapter (`transport.go`) wrapping `*websocket.Conn` to satisfy `core.Transport` interface
- Replace `gorillaDialer` with `coderDialer` using context-based `Dial`
- Remove `WithHeartbeat(pingPeriod, pongWait, writeWait)` option; replace with two independent public options: `WithPingInterval(d)` and `WithWriteTimeout(d)`
- Extract `pingPump` as a dedicated goroutine (was inlined in `writePump`), giving a 3-pump architecture: readPump + writePump + pingPump
- Replace `connectionQuit` channel with `pumpCancel` context for pump lifecycle coordination
- Make reconnect dial cancellable via quit channel — `Close()` no longer blocks on slow handshakes
- Add compile-time assertions for `MessageType` value parity between `coder/websocket` and `wspulse/core`
- Rewrite `mockTransport` to implement new `core.Transport` interface with Ping/Close observability
- Update README options table, component-tests doc, and CHANGELOG

## Checklist

### Required

- [x] `make check` passes (`fmt` → `lint` → `test`)
- [x] Each commit represents exactly one logical change
- [x] Commit messages follow the format in `commit-message-instructions.md`
- [x] No unrelated code reformatting in this PR

### Conditional (list only those that apply)

- [x] Breaking change: major version bump discussed in linked issue
- [x] `Send` and `Close` remain safe for concurrent use