### PR TITLE
feat: structured errors for OnTransportDrop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Added
+
+- `ErrNetworkUnhealthy`: returned to `OnTransportDrop` when the client sends a ping and the server does not reply within `writeTimeout`. Previously the callback received a generic `net.ErrClosed` with the root cause lost.
+- `ErrServerClosed`: returned to `OnTransportDrop` when the server initiates a WebSocket close handshake (any close frame status code). Previously the callback received a library-specific error type from `coder/websocket`.
+
 ### Changed
 
 - **BREAKING**: Replace `gorilla/websocket` (archived) with `coder/websocket` as the underlying WebSocket transport

--- a/client.go
+++ b/client.go
@@ -237,7 +237,7 @@ func (c *internalClient) readPump(ctx context.Context, transport wspulse.Transpo
 		// Capture any write or ping error BEFORE closing the transport.
 		// Priority: pingErrCh > writeErrCh > readErr.
 		// Reading before CloseNow() prevents a spurious close-induced
-		// read error from overriding the original root cause.
+		// write error from writePump from overriding the original root cause.
 		var writeErr error
 		select {
 		case writeErr = <-writeErrCh:

--- a/client.go
+++ b/client.go
@@ -22,6 +22,18 @@ var ErrRetriesExhausted = errors.New("wspulse: max reconnect retries exhausted")
 // connection and auto-reconnect is disabled.
 var ErrConnectionLost = errors.New("wspulse: connection lost")
 
+// ErrNetworkUnhealthy is returned to OnTransportDrop when the client sent a
+// ping and the server did not reply within writeTimeout. It indicates the
+// connection is unhealthy — the root cause may be a slow or unresponsive
+// server, a stale NAT entry, or any other condition that prevents the pong
+// from arriving in time.
+var ErrNetworkUnhealthy = errors.New("wspulse: network unhealthy")
+
+// ErrServerClosed is returned to OnTransportDrop when the server initiated a
+// WebSocket close handshake by sending a close frame. This is a protocol-level
+// intentional close, distinct from an abrupt network drop.
+var ErrServerClosed = errors.New("wspulse: server closed connection")
+
 // Client is the public interface for the WebSocket client.
 type Client interface {
 	// Send enqueues f for delivery to the server.
@@ -104,15 +116,16 @@ func Dial(urlStr string, opts ...ClientOption) (Client, error) {
 	pumpDone := make(chan struct{})
 	dropped := make(chan struct{})
 	writeErrCh := make(chan error, 1)
+	pingErrCh := make(chan error, 1)
 	conn := c.connection
 
 	c.pumpCancel = pumpCancel
 	c.pumpDone = pumpDone
 
 	c.goroutineWaitGroup.Add(4)
-	go func() { defer c.goroutineWaitGroup.Done(); c.readPump(pumpCtx, conn, dropped, writeErrCh) }()
+	go func() { defer c.goroutineWaitGroup.Done(); c.readPump(pumpCtx, conn, dropped, writeErrCh, pingErrCh) }()
 	go func() { defer c.goroutineWaitGroup.Done(); c.writePump(pumpCtx, conn, pumpDone, writeErrCh) }()
-	go func() { defer c.goroutineWaitGroup.Done(); c.pingPump(pumpCtx, conn) }()
+	go func() { defer c.goroutineWaitGroup.Done(); c.pingPump(pumpCtx, conn, pingErrCh) }()
 	if config.autoReconnect {
 		go func() { defer c.goroutineWaitGroup.Done(); c.reconnectLoop(dropped) }()
 	} else {
@@ -210,7 +223,7 @@ func (c *internalClient) dialOnce(ctx context.Context) error {
 	return nil
 }
 
-func (c *internalClient) readPump(ctx context.Context, transport wspulse.Transport, dropped chan struct{}, writeErrCh <-chan error) {
+func (c *internalClient) readPump(ctx context.Context, transport wspulse.Transport, dropped chan struct{}, writeErrCh <-chan error, pingErrCh <-chan error) {
 
 	var readErr error
 
@@ -221,13 +234,18 @@ func (c *internalClient) readPump(ctx context.Context, transport wspulse.Transpo
 				zap.Any("panic", r),
 			)
 		}
-		// Capture any write error BEFORE closing the transport.
-		// If writePump already failed, its error is on the channel.
+		// Capture any write or ping error BEFORE closing the transport.
+		// Priority: pingErrCh > writeErrCh > readErr.
 		// Reading before CloseNow() prevents a spurious close-induced
-		// write error from overriding the original readErr.
+		// read error from overriding the original root cause.
 		var writeErr error
 		select {
 		case writeErr = <-writeErrCh:
+		default:
+		}
+		var pingErr error
+		select {
+		case pingErr = <-pingErrCh:
 		default:
 		}
 
@@ -245,13 +263,17 @@ func (c *internalClient) readPump(ctx context.Context, transport wspulse.Transpo
 
 		// Determine the root-cause error for onTransportDrop:
 		//   1. User-initiated close → nil (behaviour contract).
-		//   2. writePump reported an error → use it (root cause).
-		//   3. Otherwise → readPump's own readErr.
+		//   2. pingPump reported ErrNetworkUnhealthy → use it (root cause lost via CloseNow).
+		//   3. writePump reported an error → use it (root cause).
+		//   4. Otherwise → readPump's own readErr (may be ErrServerClosed from adapter).
 		select {
 		case <-c.done:
 			readErr = nil
 		default:
-			if writeErr != nil {
+			switch {
+			case pingErr != nil:
+				readErr = pingErr
+			case writeErr != nil:
 				readErr = writeErr
 			}
 		}
@@ -383,14 +405,14 @@ func (c *internalClient) gracefulClose(transport wspulse.Transport) {
 	}
 }
 
-func (c *internalClient) pingPump(ctx context.Context, transport wspulse.Transport) {
+func (c *internalClient) pingPump(ctx context.Context, transport wspulse.Transport, pingErrCh chan<- error) {
 	ticker := c.clock.NewTicker(c.config.pingInterval)
 	defer ticker.Stop()
 
 	for {
 		select {
 		case <-ticker.C:
-			if err := c.doPing(ctx, transport); err != nil {
+			if err := c.doPing(ctx, transport, pingErrCh); err != nil {
 				return
 			}
 		case <-ctx.Done():
@@ -402,9 +424,10 @@ func (c *internalClient) pingPump(ctx context.Context, transport wspulse.Transpo
 // doPing sends a ping and waits for the pong within writeTimeout.
 // If the parent context is cancelled (reconnect or close), returns
 // without logging or killing the transport — that is a normal exit.
-// If the pong times out, force-closes the transport so readPump detects
-// the error.
-func (c *internalClient) doPing(ctx context.Context, transport wspulse.Transport) error {
+// If the pong times out or fails abnormally, sends ErrNetworkUnhealthy to
+// pingErrCh so readPump can report the root cause in onTransportDrop, then
+// force-closes the transport.
+func (c *internalClient) doPing(ctx context.Context, transport wspulse.Transport, pingErrCh chan<- error) error {
 	pingCtx, cancel := context.WithTimeout(ctx, c.config.writeTimeout)
 	defer cancel()
 	if err := transport.Ping(pingCtx); err != nil {
@@ -412,17 +435,15 @@ func (c *internalClient) doPing(ctx context.Context, transport wspulse.Transport
 		if ctx.Err() != nil {
 			return err
 		}
-		// Abnormal ping failure — force-close to trigger readPump error.
-		// Detailed error classification (timeout vs. TCP drop vs. policy)
-		// is handled in issue #44.
-		if errors.Is(err, context.DeadlineExceeded) {
-			c.logger.Warn("wspulse: pong timeout, closing transport",
-				zap.Error(err),
-			)
-		} else {
-			c.logger.Warn("wspulse: ping failed, closing transport",
-				zap.Error(err),
-			)
+		// Abnormal ping failure — send ErrNetworkUnhealthy to readPump
+		// before CloseNow() so the root cause is not lost when readPump
+		// sees a secondary net.ErrClosed from the closed transport.
+		c.logger.Warn("wspulse: pong timeout, closing transport",
+			zap.Error(err),
+		)
+		select {
+		case pingErrCh <- ErrNetworkUnhealthy:
+		default:
 		}
 		_ = transport.CloseNow()
 		return err
@@ -543,6 +564,7 @@ func (c *internalClient) reconnectLoop(dropped chan struct{}) {
 		newPumpCtx, newPumpCancel := context.WithCancel(context.Background())
 		newPumpDone := make(chan struct{})
 		newWriteErrCh := make(chan error, 1)
+		newPingErrCh := make(chan error, 1)
 
 		c.mu.Lock()
 		c.pumpCancel = newPumpCancel
@@ -551,9 +573,12 @@ func (c *internalClient) reconnectLoop(dropped chan struct{}) {
 		c.mu.Unlock()
 
 		c.goroutineWaitGroup.Add(3)
-		go func() { defer c.goroutineWaitGroup.Done(); c.readPump(newPumpCtx, conn, dropped, newWriteErrCh) }()
+		go func() {
+			defer c.goroutineWaitGroup.Done()
+			c.readPump(newPumpCtx, conn, dropped, newWriteErrCh, newPingErrCh)
+		}()
 		go func() { defer c.goroutineWaitGroup.Done(); c.writePump(newPumpCtx, conn, newPumpDone, newWriteErrCh) }()
-		go func() { defer c.goroutineWaitGroup.Done(); c.pingPump(newPumpCtx, conn) }()
+		go func() { defer c.goroutineWaitGroup.Done(); c.pingPump(newPumpCtx, conn, newPingErrCh) }()
 		c.logger.Info("wspulse: reconnected",
 			zap.Int("attempt", attempt),
 			zap.String("url", c.url),

--- a/client.go
+++ b/client.go
@@ -424,9 +424,10 @@ func (c *internalClient) pingPump(ctx context.Context, transport wspulse.Transpo
 // doPing sends a ping and waits for the pong within writeTimeout.
 // If the parent context is cancelled (reconnect or close), returns
 // without logging or killing the transport — that is a normal exit.
-// If the pong times out or fails abnormally, sends ErrNetworkUnhealthy to
-// pingErrCh so readPump can report the root cause in onTransportDrop, then
-// force-closes the transport.
+// If the pong times out, sends ErrNetworkUnhealthy to pingErrCh so readPump
+// can report the root cause in onTransportDrop, then force-closes the transport.
+// For other ping failures the transport is closed but pingErrCh is not written,
+// letting readPump's own error (e.g. ErrServerClosed) take priority.
 func (c *internalClient) doPing(ctx context.Context, transport wspulse.Transport, pingErrCh chan<- error) error {
 	pingCtx, cancel := context.WithTimeout(ctx, c.config.writeTimeout)
 	defer cancel()
@@ -435,15 +436,23 @@ func (c *internalClient) doPing(ctx context.Context, transport wspulse.Transport
 		if ctx.Err() != nil {
 			return err
 		}
-		// Abnormal ping failure — send ErrNetworkUnhealthy to readPump
-		// before CloseNow() so the root cause is not lost when readPump
-		// sees a secondary net.ErrClosed from the closed transport.
-		c.logger.Warn("wspulse: pong timeout, closing transport",
-			zap.Error(err),
-		)
-		select {
-		case pingErrCh <- ErrNetworkUnhealthy:
-		default:
+		if errors.Is(err, context.DeadlineExceeded) {
+			// Pong timeout — send ErrNetworkUnhealthy before CloseNow() so
+			// the root cause is not lost when readPump sees a secondary
+			// net.ErrClosed from the closed transport.
+			c.logger.Warn("wspulse: pong timeout, closing transport",
+				zap.Error(err),
+			)
+			select {
+			case pingErrCh <- ErrNetworkUnhealthy:
+			default:
+			}
+		} else {
+			// Other ping failure (e.g. transport already closing) — do not
+			// override readPump's error, which carries the real root cause.
+			c.logger.Warn("wspulse: ping failed, closing transport",
+				zap.Error(err),
+			)
 		}
 		_ = transport.CloseNow()
 		return err

--- a/transport.go
+++ b/transport.go
@@ -2,7 +2,6 @@ package client
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/coder/websocket"
 
@@ -25,9 +24,9 @@ type coderTransport struct {
 func (t *coderTransport) Read(ctx context.Context) (wspulse.MessageType, []byte, error) {
 	typ, data, err := t.conn.Read(ctx)
 	if err != nil && websocket.CloseStatus(err) != -1 {
-		// Server sent a WebSocket close frame. Wrap with ErrServerClosed so
-		// callers can use errors.Is without importing coder/websocket.
-		err = fmt.Errorf("wspulse: server closed connection: %w", ErrServerClosed)
+		// Server sent a WebSocket close frame. Return ErrServerClosed directly
+		// so callers can use errors.Is without importing coder/websocket.
+		err = ErrServerClosed
 	}
 	return wspulse.MessageType(typ), data, err
 }

--- a/transport.go
+++ b/transport.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/coder/websocket"
 
@@ -23,6 +24,11 @@ type coderTransport struct {
 
 func (t *coderTransport) Read(ctx context.Context) (wspulse.MessageType, []byte, error) {
 	typ, data, err := t.conn.Read(ctx)
+	if err != nil && websocket.CloseStatus(err) != -1 {
+		// Server sent a WebSocket close frame. Wrap with ErrServerClosed so
+		// callers can use errors.Is without importing coder/websocket.
+		err = fmt.Errorf("wspulse: server closed connection: %w", ErrServerClosed)
+	}
 	return wspulse.MessageType(typ), data, err
 }
 

--- a/transport_adapter_test.go
+++ b/transport_adapter_test.go
@@ -38,6 +38,7 @@ func TestCoderTransport_Read_WrapsCloseFrameAsErrServerClosed(t *testing.T) {
 			url := "ws" + strings.TrimPrefix(srv.URL, "http")
 			conn, _, err := websocket.Dial(context.Background(), url, nil)
 			require.NoError(t, err)
+			t.Cleanup(func() { _ = conn.CloseNow() })
 
 			transport := &coderTransport{conn: conn}
 			_, _, readErr := transport.Read(context.Background())

--- a/transport_adapter_test.go
+++ b/transport_adapter_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/coder/websocket"
 	"github.com/stretchr/testify/assert"
@@ -35,13 +36,16 @@ func TestCoderTransport_Read_WrapsCloseFrameAsErrServerClosed(t *testing.T) {
 			}))
 			t.Cleanup(srv.Close)
 
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			t.Cleanup(cancel)
+
 			url := "ws" + strings.TrimPrefix(srv.URL, "http")
-			conn, _, err := websocket.Dial(context.Background(), url, nil)
+			conn, _, err := websocket.Dial(ctx, url, nil)
 			require.NoError(t, err)
 			t.Cleanup(func() { _ = conn.CloseNow() })
 
 			transport := &coderTransport{conn: conn}
-			_, _, readErr := transport.Read(context.Background())
+			_, _, readErr := transport.Read(ctx)
 
 			require.Error(t, readErr)
 			assert.ErrorIs(t, readErr, ErrServerClosed,

--- a/transport_adapter_test.go
+++ b/transport_adapter_test.go
@@ -1,0 +1,50 @@
+package client
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/coder/websocket"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCoderTransport_Read_WrapsCloseFrameAsErrServerClosed verifies that
+// coderTransport.Read wraps any WebSocket close frame into ErrServerClosed.
+// This ensures callers do not need to import coder/websocket to classify the
+// error — errors.Is(err, ErrServerClosed) is sufficient.
+func TestCoderTransport_Read_WrapsCloseFrameAsErrServerClosed(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		code websocket.StatusCode
+	}{
+		{"normal closure (1000)", websocket.StatusNormalClosure},
+		{"policy violation (1008)", websocket.StatusPolicyViolation},
+		{"going away (1001)", websocket.StatusGoingAway},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				conn, err := websocket.Accept(w, r, nil)
+				require.NoError(t, err)
+				_ = conn.Close(tc.code, "test close")
+			}))
+			t.Cleanup(srv.Close)
+
+			url := "ws" + strings.TrimPrefix(srv.URL, "http")
+			conn, _, err := websocket.Dial(context.Background(), url, nil)
+			require.NoError(t, err)
+
+			transport := &coderTransport{conn: conn}
+			_, _, readErr := transport.Read(context.Background())
+
+			require.Error(t, readErr)
+			assert.ErrorIs(t, readErr, ErrServerClosed,
+				"want ErrServerClosed for close code %d, got: %v", tc.code, readErr)
+		})
+	}
+}

--- a/transport_adapter_test.go
+++ b/transport_adapter_test.go
@@ -31,7 +31,10 @@ func TestCoderTransport_Read_WrapsCloseFrameAsErrServerClosed(t *testing.T) {
 
 			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				conn, err := websocket.Accept(w, r, nil)
-				require.NoError(t, err)
+				if err != nil {
+					t.Errorf("websocket.Accept: %v", err)
+					return
+				}
 				_ = conn.Close(tc.code, "test close")
 			}))
 			t.Cleanup(srv.Close)

--- a/transport_drop_test.go
+++ b/transport_drop_test.go
@@ -16,12 +16,12 @@ import (
 
 func TestOnTransportDrop_PongTimeout_IsErrNetworkUnhealthy(t *testing.T) {
 	t.Parallel()
-	// Ping blocks until writeTimeout expires, simulating a server that never
-	// replies. OnTransportDrop must receive ErrNetworkUnhealthy.
+	// pingFunc returns DeadlineExceeded immediately so the test does not
+	// depend on any real wall-clock timeout. OnTransportDrop must receive
+	// ErrNetworkUnhealthy.
 	mt := newMockTransport()
-	mt.pingFunc = func(ctx context.Context) error {
-		<-ctx.Done()
-		return ctx.Err()
+	mt.pingFunc = func(context.Context) error {
+		return context.DeadlineExceeded
 	}
 	fc := newFakeClock()
 
@@ -30,7 +30,6 @@ func TestOnTransportDrop_PongTimeout_IsErrNetworkUnhealthy(t *testing.T) {
 		client.WithDialer(newMockDialer(mockDialResult{transport: mt})),
 		client.WithClock(fc),
 		client.WithPingInterval(50*time.Millisecond),
-		client.WithWriteTimeout(50*time.Millisecond),
 		client.WithOnTransportDrop(func(e error) { dropErr <- e }),
 	)
 	require.NoError(t, err)

--- a/transport_drop_test.go
+++ b/transport_drop_test.go
@@ -1,0 +1,66 @@
+package client_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/wspulse/client-go"
+)
+
+// A1 — ErrNetworkUnhealthy: pong timeout path
+
+func TestOnTransportDrop_PongTimeout_IsErrNetworkUnhealthy(t *testing.T) {
+	t.Parallel()
+	// Ping blocks until writeTimeout expires, simulating a server that never
+	// replies. OnTransportDrop must receive ErrNetworkUnhealthy.
+	mt := newMockTransport()
+	mt.pingFunc = func(ctx context.Context) error {
+		<-ctx.Done()
+		return ctx.Err()
+	}
+	fc := newFakeClock()
+
+	dropErr := make(chan error, 1)
+	c, err := client.Dial("ws://mock",
+		client.WithDialer(newMockDialer(mockDialResult{transport: mt})),
+		client.WithClock(fc),
+		client.WithPingInterval(50*time.Millisecond),
+		client.WithWriteTimeout(50*time.Millisecond),
+		client.WithOnTransportDrop(func(e error) { dropErr <- e }),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = c.Close() })
+
+	// Wait for pingPump to register its ticker, then fire it.
+	requireReceive(t, fc.tickerAdded)
+	fc.fireTicker(0)
+
+	got := requireReceive(t, dropErr)
+	assert.ErrorIs(t, got, client.ErrNetworkUnhealthy,
+		"want ErrNetworkUnhealthy on pong timeout, got: %v", got)
+}
+
+// B1 — ErrServerClosed: server close frame path (component — mock transport)
+
+func TestOnTransportDrop_ServerClosedFrame_IsErrServerClosed(t *testing.T) {
+	t.Parallel()
+	// The transport adapter wraps coder/websocket close frame errors into
+	// ErrServerClosed before they reach readPump. Inject the already-wrapped
+	// error via mock to verify the readPump → onTransportDrop plumbing.
+	dropErr := make(chan error, 1)
+	c, mt, _ := dialWithMock(t,
+		client.WithOnTransportDrop(func(e error) { dropErr <- e }),
+	)
+	t.Cleanup(func() { _ = c.Close() })
+
+	mt.InjectError(fmt.Errorf("wspulse: server closed connection: %w", client.ErrServerClosed))
+
+	got := requireReceive(t, dropErr)
+	assert.ErrorIs(t, got, client.ErrServerClosed,
+		"want ErrServerClosed on server close frame, got: %v", got)
+}

--- a/transport_drop_test.go
+++ b/transport_drop_test.go
@@ -2,7 +2,6 @@ package client_test
 
 import (
 	"context"
-	"fmt"
 	"testing"
 	"time"
 
@@ -48,16 +47,16 @@ func TestOnTransportDrop_PongTimeout_IsErrNetworkUnhealthy(t *testing.T) {
 
 func TestOnTransportDrop_ServerClosedFrame_IsErrServerClosed(t *testing.T) {
 	t.Parallel()
-	// The transport adapter wraps coder/websocket close frame errors into
-	// ErrServerClosed before they reach readPump. Inject the already-wrapped
-	// error via mock to verify the readPump → onTransportDrop plumbing.
+	// The transport adapter returns ErrServerClosed directly when the server
+	// sends a close frame. Inject it via mock to verify the
+	// readPump → onTransportDrop propagation path.
 	dropErr := make(chan error, 1)
 	c, mt, _ := dialWithMock(t,
 		client.WithOnTransportDrop(func(e error) { dropErr <- e }),
 	)
 	t.Cleanup(func() { _ = c.Close() })
 
-	mt.InjectError(fmt.Errorf("wspulse: server closed connection: %w", client.ErrServerClosed))
+	mt.InjectError(client.ErrServerClosed)
 
 	got := requireReceive(t, dropErr)
 	assert.ErrorIs(t, got, client.ErrServerClosed,


### PR DESCRIPTION
## Summary

Add two sentinel errors to `OnTransportDrop(err)` so consumers can use `errors.Is` to distinguish transport drop causes without depending on `coder/websocket` internals. The client is the active reconnection decision-maker; different error causes warrant different reconnect strategies.

## Related issues

Closes #44
Relates to wspulse/.github#36

## Changes

- `client.go`: add `ErrNetworkUnhealthy` and `ErrServerClosed` sentinel declarations
- `client.go`: add `pingErrCh chan error` (cap 1) shared between `pingPump` and `readPump`, mirroring the existing `writeErrCh` pattern; `doPing` sends `ErrNetworkUnhealthy` before `CloseNow()` so the root cause is not lost when `readPump` receives a secondary `net.ErrClosed`
- `client.go`: `readPump` defer now reads `pingErrCh` first, then `writeErrCh`, then falls back to its own `readErr`; priority: ping error > write error > read error
- `transport.go`: `coderTransport.Read()` wraps any `coder/websocket` close frame error (detected via `websocket.CloseStatus`) into `ErrServerClosed`; callers no longer need to import `coder/websocket` to classify the error
- `transport_drop_test.go`: component tests — pong timeout delivers `ErrNetworkUnhealthy`; server close frame (via mock) delivers `ErrServerClosed`
- `transport_adapter_test.go`: adapter unit tests using `httptest` + `coder/websocket` — verifies `coderTransport.Read()` wraps close codes 1000, 1001, and 1008 into `ErrServerClosed`

## Checklist

### Required

- [x] `make check` passes (`fmt` → `lint` → `test`)
- [x] Each commit represents exactly one logical change
- [x] Commit messages follow the format in `commit-message-instructions.md`
- [x] No unrelated code reformatting in this PR

### Conditional

- [x] New public API: includes GoDoc comments (`ErrNetworkUnhealthy`, `ErrServerClosed`)
- [x] Bug fix: includes a test that fails before the fix and passes after (`TestOnTransportDrop_PongTimeout_IsErrNetworkUnhealthy`, `TestCoderTransport_Read_WrapsCloseFrameAsErrServerClosed`)
- [x] `Send` and `Close` remain safe for concurrent use