### PR TITLE
feat: remove client-side ping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Removed
+
+- **BREAKING**: `WithPingInterval` option — client-side ping is removed; dead-connection detection is now handled exclusively by the Hub's server-side heartbeat.
+- **BREAKING**: `ErrNetworkUnhealthy` sentinel error — no longer applicable without client-side ping.
+
 ## [0.7.0] - 2026-04-15
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -80,8 +80,6 @@ client.WithOnMessage(func(f wspulse.Frame) {
         // handle message
     case "chat.ack":
         // handle acknowledgement
-    case "pong":
-        // heartbeat response
     }
 })
 ```
@@ -137,7 +135,6 @@ See [wspulse/core](https://github.com/wspulse/core) for the full `router` API.
 | `WithOnDisconnect(fn)`                   | —               |
 | `WithOnTransportDrop(fn)`                | —               |
 | `WithAutoReconnect(max, base, maxDelay)` | disabled              |
-| `WithPingInterval(d)`                    | 20s                   |
 | `WithWriteTimeout(d)`                    | 10s                   |
 | `WithMaxMessageSize(n)`                  | 1 MiB                 |
 | `WithCodec(c)`                           | JSONCodec             |

--- a/client.go
+++ b/client.go
@@ -22,13 +22,6 @@ var ErrRetriesExhausted = errors.New("wspulse: max reconnect retries exhausted")
 // connection and auto-reconnect is disabled.
 var ErrConnectionLost = errors.New("wspulse: connection lost")
 
-// ErrNetworkUnhealthy is returned to OnTransportDrop when the client sent a
-// ping and the server did not reply within writeTimeout. It indicates the
-// connection is unhealthy — the root cause may be a slow or unresponsive
-// server, a stale NAT entry, or any other condition that prevents the pong
-// from arriving in time.
-var ErrNetworkUnhealthy = errors.New("wspulse: network unhealthy")
-
 // ErrServerClosed is returned to OnTransportDrop when the server initiated a
 // WebSocket close handshake by sending a close frame. This is a protocol-level
 // intentional close, distinct from an abrupt network drop.
@@ -58,13 +51,11 @@ type Client interface {
 //     reconnectLoop to stop.
 //
 // Pump lifecycle:
-//   - pumpCancel : cancels the pump context, causing readPump, writePump,
-//     and pingPump to exit. Called on reconnect (to swap pumps) and on
-//     Close() (to shut down permanently).
+//   - pumpCancel : cancels the pump context, causing readPump and writePump
+//     to exit. Called on reconnect (to swap pumps) and on Close() (to shut
+//     down permanently).
 //   - pumpDone   : closed by writePump on exit; used by reconnectLoop
 //     to wait for the old pumps before starting new ones.
-//   - pingPump   : exits via context cancellation; its errors propagate
-//     through CloseNow() → readPump (which sees a read error).
 type internalClient struct {
 	url                string
 	config             *clientConfig
@@ -116,16 +107,14 @@ func Dial(urlStr string, opts ...ClientOption) (Client, error) {
 	pumpDone := make(chan struct{})
 	dropped := make(chan struct{})
 	writeErrCh := make(chan error, 1)
-	pingErrCh := make(chan error, 1)
 	conn := c.connection
 
 	c.pumpCancel = pumpCancel
 	c.pumpDone = pumpDone
 
-	c.goroutineWaitGroup.Add(4)
-	go func() { defer c.goroutineWaitGroup.Done(); c.readPump(pumpCtx, conn, dropped, writeErrCh, pingErrCh) }()
+	c.goroutineWaitGroup.Add(3)
+	go func() { defer c.goroutineWaitGroup.Done(); c.readPump(pumpCtx, conn, dropped, writeErrCh) }()
 	go func() { defer c.goroutineWaitGroup.Done(); c.writePump(pumpCtx, conn, pumpDone, writeErrCh) }()
-	go func() { defer c.goroutineWaitGroup.Done(); c.pingPump(pumpCtx, conn, pingErrCh) }()
 	if config.autoReconnect {
 		go func() { defer c.goroutineWaitGroup.Done(); c.reconnectLoop(dropped) }()
 	} else {
@@ -223,7 +212,7 @@ func (c *internalClient) dialOnce(ctx context.Context) error {
 	return nil
 }
 
-func (c *internalClient) readPump(ctx context.Context, transport wspulse.Transport, dropped chan struct{}, writeErrCh <-chan error, pingErrCh <-chan error) {
+func (c *internalClient) readPump(ctx context.Context, transport wspulse.Transport, dropped chan struct{}, writeErrCh <-chan error) {
 
 	var readErr error
 
@@ -234,18 +223,13 @@ func (c *internalClient) readPump(ctx context.Context, transport wspulse.Transpo
 				zap.Any("panic", r),
 			)
 		}
-		// Capture any write or ping error BEFORE closing the transport.
-		// Priority: pingErrCh > writeErrCh > readErr.
+		// Capture any write error BEFORE closing the transport.
+		// Priority: writeErrCh > readErr.
 		// Reading before CloseNow() prevents a spurious close-induced
 		// write error from writePump from overriding the original root cause.
 		var writeErr error
 		select {
 		case writeErr = <-writeErrCh:
-		default:
-		}
-		var pingErr error
-		select {
-		case pingErr = <-pingErrCh:
 		default:
 		}
 
@@ -263,17 +247,13 @@ func (c *internalClient) readPump(ctx context.Context, transport wspulse.Transpo
 
 		// Determine the root-cause error for onTransportDrop:
 		//   1. User-initiated close → nil (behaviour contract).
-		//   2. pingPump reported ErrNetworkUnhealthy → use it (root cause lost via CloseNow).
-		//   3. writePump reported an error → use it (root cause).
-		//   4. Otherwise → readPump's own readErr (may be ErrServerClosed from adapter).
+		//   2. writePump reported an error → use it (root cause).
+		//   3. Otherwise → readPump's own readErr (may be ErrServerClosed from adapter).
 		select {
 		case <-c.done:
 			readErr = nil
 		default:
-			switch {
-			case pingErr != nil:
-				readErr = pingErr
-			case writeErr != nil:
+			if writeErr != nil {
 				readErr = writeErr
 			}
 		}
@@ -405,61 +385,6 @@ func (c *internalClient) gracefulClose(transport wspulse.Transport) {
 	}
 }
 
-func (c *internalClient) pingPump(ctx context.Context, transport wspulse.Transport, pingErrCh chan<- error) {
-	ticker := c.clock.NewTicker(c.config.pingInterval)
-	defer ticker.Stop()
-
-	for {
-		select {
-		case <-ticker.C:
-			if err := c.doPing(ctx, transport, pingErrCh); err != nil {
-				return
-			}
-		case <-ctx.Done():
-			return
-		}
-	}
-}
-
-// doPing sends a ping and waits for the pong within writeTimeout.
-// If the parent context is cancelled (reconnect or close), returns
-// without logging or killing the transport — that is a normal exit.
-// If the pong times out, sends ErrNetworkUnhealthy to pingErrCh so readPump
-// can report the root cause in onTransportDrop, then force-closes the transport.
-// For other ping failures the transport is closed but pingErrCh is not written,
-// letting readPump's own error (e.g. ErrServerClosed) take priority.
-func (c *internalClient) doPing(ctx context.Context, transport wspulse.Transport, pingErrCh chan<- error) error {
-	pingCtx, cancel := context.WithTimeout(ctx, c.config.writeTimeout)
-	defer cancel()
-	if err := transport.Ping(pingCtx); err != nil {
-		// Parent context cancelled — normal shutdown or reconnect.
-		if ctx.Err() != nil {
-			return err
-		}
-		if errors.Is(err, context.DeadlineExceeded) {
-			// Pong timeout — send ErrNetworkUnhealthy before CloseNow() so
-			// the root cause is not lost when readPump sees a secondary
-			// net.ErrClosed from the closed transport.
-			c.logger.Warn("wspulse: pong timeout, closing transport",
-				zap.Error(err),
-			)
-			select {
-			case pingErrCh <- ErrNetworkUnhealthy:
-			default:
-			}
-		} else {
-			// Other ping failure (e.g. transport already closing) — do not
-			// override readPump's error, which carries the real root cause.
-			c.logger.Warn("wspulse: ping failed, closing transport",
-				zap.Error(err),
-			)
-		}
-		_ = transport.CloseNow()
-		return err
-	}
-	return nil
-}
-
 func (c *internalClient) reconnectLoop(dropped chan struct{}) {
 	var disconnectErr error
 	defer func() {
@@ -573,7 +498,6 @@ func (c *internalClient) reconnectLoop(dropped chan struct{}) {
 		newPumpCtx, newPumpCancel := context.WithCancel(context.Background())
 		newPumpDone := make(chan struct{})
 		newWriteErrCh := make(chan error, 1)
-		newPingErrCh := make(chan error, 1)
 
 		c.mu.Lock()
 		c.pumpCancel = newPumpCancel
@@ -581,13 +505,12 @@ func (c *internalClient) reconnectLoop(dropped chan struct{}) {
 		conn := c.connection
 		c.mu.Unlock()
 
-		c.goroutineWaitGroup.Add(3)
+		c.goroutineWaitGroup.Add(2)
 		go func() {
 			defer c.goroutineWaitGroup.Done()
-			c.readPump(newPumpCtx, conn, dropped, newWriteErrCh, newPingErrCh)
+			c.readPump(newPumpCtx, conn, dropped, newWriteErrCh)
 		}()
 		go func() { defer c.goroutineWaitGroup.Done(); c.writePump(newPumpCtx, conn, newPumpDone, newWriteErrCh) }()
-		go func() { defer c.goroutineWaitGroup.Done(); c.pingPump(newPumpCtx, conn, newPingErrCh) }()
 		c.logger.Info("wspulse: reconnected",
 			zap.Int("attempt", attempt),
 			zap.String("url", c.url),

--- a/client_test.go
+++ b/client_test.go
@@ -64,26 +64,6 @@ func TestClient_WithCodec_Nil_Panics(t *testing.T) {
 	})
 }
 
-func TestClient_WithPingInterval_InvalidParams_Panics(t *testing.T) {
-	t.Parallel()
-	cases := []struct {
-		name    string
-		d       time.Duration
-		wantMsg string
-	}{
-		{"zero", 0, "wspulse: pingInterval must be positive"},
-		{"negative", -1 * time.Second, "wspulse: pingInterval must be positive"},
-		{"exceeds max", 2 * time.Minute, "wspulse: pingInterval exceeds maximum (1m)"},
-	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			require.PanicsWithValue(t, tc.wantMsg, func() {
-				_ = client.WithPingInterval(tc.d)
-			})
-		})
-	}
-}
-
 func TestClient_WithWriteTimeout_InvalidParams_Panics(t *testing.T) {
 	t.Parallel()
 	cases := []struct {
@@ -262,24 +242,6 @@ func TestClient_WithMaxMessageSize_BoundaryValues(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			opt := client.WithMaxMessageSize(tc.n)
-			assert.NotNil(t, opt)
-		})
-	}
-}
-
-func TestClient_WithPingInterval_ValidParams_NoPanic(t *testing.T) {
-	t.Parallel()
-	cases := []struct {
-		name string
-		d    time.Duration
-	}{
-		{"minimum", 1 * time.Millisecond},
-		{"typical", 20 * time.Second},
-		{"maximum", 1 * time.Minute},
-	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			opt := client.WithPingInterval(tc.d)
 			assert.NotNil(t, opt)
 		})
 	}

--- a/clock.go
+++ b/clock.go
@@ -5,7 +5,6 @@ import "time"
 // clock abstracts time operations for testability.
 type clock interface {
 	NewTimer(d time.Duration) *time.Timer
-	NewTicker(d time.Duration) *time.Ticker
 }
 
 // realClock delegates to the time package.
@@ -13,8 +12,4 @@ type realClock struct{}
 
 func (realClock) NewTimer(d time.Duration) *time.Timer {
 	return time.NewTimer(d)
-}
-
-func (realClock) NewTicker(d time.Duration) *time.Ticker {
-	return time.NewTicker(d)
 }

--- a/doc/component-tests.md
+++ b/doc/component-tests.md
@@ -19,9 +19,8 @@ deterministic and run with `make check`.
 | 4   | Max retries exhausted, `Done()` closes                              | `TestAutoReconnect_MaxRetriesExhausted_ClosesDone`           | reconnect_test.go   |
 | 5   | `Close()` during reconnect/backoff, loop stops cleanly              | `TestAutoReconnect_CloseDuringBackoff`                       | reconnect_test.go   |
 | 6   | `Send()` on closed client, `ErrConnectionClosed`                    | `TestSend_AfterClose_ReturnsErrConnectionClosed`             | basic_test.go       |
-| 7   | Heartbeat ping then read error, client disconnects with non-nil error | `TestHeartbeat_ReadError_DisconnectsClient`                  | misc_test.go        |
-| 8   | Concurrent sends: no data race or interleaving                      | `TestConcurrentSendAndClose_NoRace`                          | lifecycle_test.go   |
-| 9   | Concurrent `Close()` + transport drop, `onDisconnect` exactly once  | `TestConcurrentCloseAndTransportDrop_OnDisconnectExactlyOnce`| lifecycle_test.go   |
+| 7   | Concurrent sends: no data race or interleaving                      | `TestConcurrentSendAndClose_NoRace`                          | lifecycle_test.go   |
+| 8   | Concurrent `Close()` + transport drop, `onDisconnect` exactly once  | `TestConcurrentCloseAndTransportDrop_OnDisconnectExactlyOnce`| lifecycle_test.go   |
 
 ## Additional Tests
 
@@ -78,9 +77,6 @@ deterministic and run with `make check`.
 | `TestWithDialHeaders`                              | Custom dial headers are forwarded to the dialer               |
 | `TestWithMaxMessageSize`                           | `SetReadLimit` is called with configured size                 |
 | `TestWithMaxMessageSize_OversizedMessage`          | Oversized message triggers read error                         |
-| `TestPingInterval_SendsPings`                      | Ping messages are sent at configured interval                 |
-| `TestPongTimeout_DisconnectsClient`                | Pong timeout force-closes transport                           |
-| `TestWithPingInterval_ValidParams_Applied`         | `WithPingInterval` option is accepted                         |
 | `TestWithLogger_ValidLogger_Applied`               | `WithLogger` option is accepted                               |
 
-**Total: 42 component tests** (9 contract scenarios + additional per-feature tests).
+**Total: 38 component tests** (8 contract scenarios + additional per-feature tests).

--- a/misc_test.go
+++ b/misc_test.go
@@ -1,13 +1,10 @@
 package client_test
 
 import (
-	"context"
 	"errors"
-	"net"
 	"net/http"
 	"sync"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -119,111 +116,6 @@ func TestSend_EncodeError_ReturnsError(t *testing.T) {
 	require.Error(t, err, "expected encode error")
 }
 
-func TestPingInterval_SendsPings(t *testing.T) {
-	t.Parallel()
-	// Verify that with a fake clock, firing the heartbeat ticker causes a ping.
-	mt := newMockTransport()
-	mt.pingCh = make(chan struct{}, 16)
-	fc := newFakeClock()
-	md := newMockDialer(mockDialResult{transport: mt})
-
-	c, err := client.Dial("ws://mock",
-		client.WithDialer(md),
-		client.WithClock(fc),
-		client.WithPingInterval(50*time.Millisecond),
-		client.WithWriteTimeout(5*time.Second),
-	)
-	require.NoError(t, err, "Dial failed")
-	t.Cleanup(func() { _ = c.Close() })
-
-	// Wait for pingPump to create the heartbeat ticker.
-	requireReceive(t, fc.tickerAdded)
-
-	// Fire the ticker to trigger a ping.
-	fc.fireTicker(0)
-
-	// Verify ping was called.
-	requireReceive(t, mt.pingCh)
-	fc.stopTicker(0)
-}
-
-func TestHeartbeat_ReadError_DisconnectsClient(t *testing.T) {
-	t.Parallel()
-	// Verifies the observable heartbeat behaviour: the client sends pings
-	// via the heartbeat ticker, and when the transport dies the client disconnects.
-	mt := newMockTransport()
-	mt.pingCh = make(chan struct{}, 16)
-	fc := newFakeClock()
-	md := newMockDialer(mockDialResult{transport: mt})
-
-	disconnected := make(chan error, 1)
-	c, err := client.Dial("ws://mock",
-		client.WithDialer(md),
-		client.WithClock(fc),
-		client.WithPingInterval(50*time.Millisecond),
-		client.WithWriteTimeout(10*time.Second),
-		client.WithOnDisconnect(func(err error) {
-			disconnected <- err
-		}),
-	)
-	require.NoError(t, err, "Dial failed")
-	t.Cleanup(func() { _ = c.Close() })
-
-	// Wait for pingPump to create the heartbeat ticker.
-	requireReceive(t, fc.tickerAdded)
-
-	// Fire the ticker to trigger a ping.
-	fc.fireTicker(0)
-
-	// Verify a ping was sent.
-	requireReceive(t, mt.pingCh)
-	fc.stopTicker(0)
-
-	// Kill the transport to simulate a connection loss.
-	mt.InjectError(&net.OpError{Op: "read", Err: errors.New("i/o timeout")})
-
-	got := requireReceive(t, disconnected)
-	assert.Error(t, got, "want non-nil error on disconnect")
-
-	requireDone(t, c)
-}
-
-func TestPongTimeout_DisconnectsClient(t *testing.T) {
-	t.Parallel()
-	// When the server never responds to a ping, pingPump force-closes the
-	// transport. pingFunc returns context.DeadlineExceeded immediately so
-	// the test does not depend on any real wall-clock timeout.
-	mt := newMockTransport()
-	mt.pingFunc = func(ctx context.Context) error {
-		return context.DeadlineExceeded
-	}
-	fc := newFakeClock()
-	md := newMockDialer(mockDialResult{transport: mt})
-
-	transportDropped := make(chan error, 1)
-	c, err := client.Dial("ws://mock",
-		client.WithDialer(md),
-		client.WithClock(fc),
-		client.WithPingInterval(50*time.Millisecond),
-		client.WithOnTransportDrop(func(err error) {
-			transportDropped <- err
-		}),
-	)
-	require.NoError(t, err, "Dial failed")
-	t.Cleanup(func() { _ = c.Close() })
-
-	// Wait for pingPump to create the ticker.
-	requireReceive(t, fc.tickerAdded)
-
-	// Fire the ticker — pingFunc returns DeadlineExceeded immediately,
-	// doPing calls CloseNow(), readPump signals onTransportDrop.
-	fc.fireTicker(0)
-
-	got := requireReceive(t, transportDropped)
-	assert.Error(t, got, "want non-nil error on pong timeout")
-	fc.stopTicker(0)
-}
-
 func TestWithDialHeaders(t *testing.T) {
 	t.Parallel()
 	// WithDialHeaders passes headers to the dialer. We verify the mock dialer
@@ -327,14 +219,5 @@ func TestWithLogger_ValidLogger_Applied(t *testing.T) {
 	// panic and the client can be created and closed.
 	logger, _ := zap.NewDevelopment()
 	c, _, _ := dialWithMock(t, client.WithLogger(logger))
-	_ = c.Close()
-}
-
-func TestWithPingInterval_ValidParams_Applied(t *testing.T) {
-	t.Parallel()
-	c, _, _ := dialWithMock(t,
-		client.WithPingInterval(5*time.Second),
-		client.WithWriteTimeout(3*time.Second),
-	)
 	_ = c.Close()
 }

--- a/mock_transport_test.go
+++ b/mock_transport_test.go
@@ -24,13 +24,11 @@ type mockTransport struct {
 
 	mu           sync.Mutex
 	readLimit    int64
-	readLimitSet chan struct{}                   // signaled once when SetReadLimit is first called with a non-zero value
-	writeEntered chan struct{}                   // when non-nil, signaled each time Write is entered (before blocking)
-	pingCh       chan struct{}                   // when non-nil, signaled each time Ping is called
-	pingFunc     func(ctx context.Context) error // when non-nil, Ping delegates to this function
-	closeCalled  chan closeCall                  // when non-nil, signaled on Close(code, reason)
-	writeErr     error                           // when non-nil, Write returns this error immediately
-	closeHook    func()                          // when non-nil, runs inside doClose after closeCh is closed
+	readLimitSet chan struct{}  // signaled once when SetReadLimit is first called with a non-zero value
+	writeEntered chan struct{}  // when non-nil, signaled each time Write is entered (before blocking)
+	closeCalled  chan closeCall // when non-nil, signaled on Close(code, reason)
+	writeErr     error          // when non-nil, Write returns this error immediately
+	closeHook    func()         // when non-nil, runs inside doClose after closeCh is closed
 	closed       bool
 }
 
@@ -121,19 +119,7 @@ func (m *mockTransport) Write(ctx context.Context, typ wspulse.MessageType, data
 	}
 }
 
-func (m *mockTransport) Ping(ctx context.Context) error {
-	if m.pingCh != nil {
-		select {
-		case m.pingCh <- struct{}{}:
-		default:
-		}
-	}
-	m.mu.Lock()
-	fn := m.pingFunc
-	m.mu.Unlock()
-	if fn != nil {
-		return fn(ctx)
-	}
+func (m *mockTransport) Ping(_ context.Context) error {
 	return nil
 }
 

--- a/options.go
+++ b/options.go
@@ -12,7 +12,6 @@ import (
 
 // Configuration upper bounds — option functions panic if these ceilings are exceeded.
 const (
-	maxPingInterval  = 1 * time.Minute  // WithPingInterval upper bound
 	maxWriteTimeout  = 30 * time.Second // WithWriteTimeout upper bound
 	maxMsgSizeBytes  = 64 << 20         // WithMaxMessageSize upper bound — 64 MiB
 	maxBaseDelay     = 1 * time.Minute  // WithAutoReconnect: baseDelay upper bound
@@ -36,7 +35,6 @@ type clientConfig struct {
 	maxRetries         int // 0 means retry indefinitely
 	baseDelay          time.Duration
 	maxDelay           time.Duration
-	pingInterval       time.Duration
 	writeTimeout       time.Duration
 	maxMessageSize     int64 // max inbound message size in bytes; 0 = no size enforcement
 	sendBufferSize     int   // outbound channel capacity (number of frames)
@@ -52,7 +50,6 @@ func defaultClientConfig() *clientConfig {
 		maxRetries:     10,
 		baseDelay:      1 * time.Second,
 		maxDelay:       30 * time.Second,
-		pingInterval:   20 * time.Second,
 		writeTimeout:   10 * time.Second,
 		maxMessageSize: 1 << 20, // 1 MiB
 		sendBufferSize: 256,
@@ -142,21 +139,8 @@ func WithLogger(logger *zap.Logger) ClientOption {
 	return func(c *clientConfig) { c.logger = logger }
 }
 
-// WithPingInterval sets the interval between heartbeat pings.
-// d must be in (0, 1m]. Default is 20s.
-func WithPingInterval(d time.Duration) ClientOption {
-	if d <= 0 {
-		panic("wspulse: pingInterval must be positive")
-	}
-	if d > maxPingInterval {
-		panic("wspulse: pingInterval exceeds maximum (1m)")
-	}
-	return func(c *clientConfig) { c.pingInterval = d }
-}
-
-// WithWriteTimeout sets the timeout for all write operations: data frames,
-// ping/pong, and the close handshake. Pong must arrive within this duration
-// or the connection is considered dead. d must be in (0, 30s]. Default is 10s.
+// WithWriteTimeout sets the timeout for write operations: data frames and the
+// close handshake. d must be in (0, 30s]. Default is 10s.
 func WithWriteTimeout(d time.Duration) ClientOption {
 	if d <= 0 {
 		panic("wspulse: writeTimeout must be positive")

--- a/testhelpers_test.go
+++ b/testhelpers_test.go
@@ -18,14 +18,12 @@ import (
 
 // ── fakeClock ────────────────────────────────────────────────────────────────
 
-// fakeClock replaces both NewTimer (backoff) and NewTicker (heartbeat) with
-// controllable fakes. No real timers fire — tests drive time explicitly.
+// fakeClock replaces NewTimer (backoff) with a controllable fake.
+// No real timers fire — tests drive time explicitly.
 type fakeClock struct {
-	mu          sync.Mutex
-	timers      []*fakeTimerEntry
-	tickers     []*fakeTickerEntry
-	timerAdded  chan struct{}
-	tickerAdded chan struct{}
+	mu         sync.Mutex
+	timers     []*fakeTimerEntry
+	timerAdded chan struct{}
 }
 
 type fakeTimerEntry struct {
@@ -33,13 +31,8 @@ type fakeTimerEntry struct {
 	timer *time.Timer
 }
 
-type fakeTickerEntry struct {
-	d      time.Duration
-	ticker *time.Ticker
-}
-
 func newFakeClock() *fakeClock {
-	return &fakeClock{timerAdded: make(chan struct{}, 16), tickerAdded: make(chan struct{}, 16)}
+	return &fakeClock{timerAdded: make(chan struct{}, 16)}
 }
 
 // NewTimer returns a stopped timer that will not fire on its own.
@@ -56,50 +49,11 @@ func (fc *fakeClock) NewTimer(d time.Duration) *time.Timer {
 	return t
 }
 
-// NewTicker returns a stopped ticker that will never fire on its own.
-func (fc *fakeClock) NewTicker(d time.Duration) *time.Ticker {
-	t := time.NewTicker(time.Hour)
-	t.Stop()
-	fc.mu.Lock()
-	fc.tickers = append(fc.tickers, &fakeTickerEntry{d: d, ticker: t})
-	select {
-	case fc.tickerAdded <- struct{}{}:
-	default:
-	}
-	fc.mu.Unlock()
-	return t
-}
-
 // TimerCount returns the number of registered timers.
 func (fc *fakeClock) TimerCount() int {
 	fc.mu.Lock()
 	defer fc.mu.Unlock()
 	return len(fc.timers)
-}
-
-// TickerCount returns the number of registered tickers.
-func (fc *fakeClock) TickerCount() int {
-	fc.mu.Lock()
-	defer fc.mu.Unlock()
-	return len(fc.tickers)
-}
-
-// fireTicker fires the i-th registered ticker by resetting it to 1ns.
-// The consumer (pingPump) reads from ticker.C and acts on the tick.
-// Call stopTicker(i) after verifying the side effect to prevent repeated ticks.
-func (fc *fakeClock) fireTicker(i int) {
-	fc.mu.Lock()
-	t := fc.tickers[i].ticker
-	fc.mu.Unlock()
-	t.Reset(time.Nanosecond)
-}
-
-// stopTicker stops the i-th registered ticker.
-func (fc *fakeClock) stopTicker(i int) {
-	fc.mu.Lock()
-	t := fc.tickers[i].ticker
-	fc.mu.Unlock()
-	t.Stop()
 }
 
 // ── helpers ──────────────────────────────────────────────────────────────────

--- a/transport_drop_test.go
+++ b/transport_drop_test.go
@@ -1,47 +1,12 @@
 package client_test
 
 import (
-	"context"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 
 	"github.com/wspulse/client-go"
 )
-
-// A1 — ErrNetworkUnhealthy: pong timeout path
-
-func TestOnTransportDrop_PongTimeout_IsErrNetworkUnhealthy(t *testing.T) {
-	t.Parallel()
-	// pingFunc returns DeadlineExceeded immediately so the test does not
-	// depend on any real wall-clock timeout. OnTransportDrop must receive
-	// ErrNetworkUnhealthy.
-	mt := newMockTransport()
-	mt.pingFunc = func(context.Context) error {
-		return context.DeadlineExceeded
-	}
-	fc := newFakeClock()
-
-	dropErr := make(chan error, 1)
-	c, err := client.Dial("ws://mock",
-		client.WithDialer(newMockDialer(mockDialResult{transport: mt})),
-		client.WithClock(fc),
-		client.WithPingInterval(50*time.Millisecond),
-		client.WithOnTransportDrop(func(e error) { dropErr <- e }),
-	)
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = c.Close() })
-
-	// Wait for pingPump to register its ticker, then fire it.
-	requireReceive(t, fc.tickerAdded)
-	fc.fireTicker(0)
-
-	got := requireReceive(t, dropErr)
-	assert.ErrorIs(t, got, client.ErrNetworkUnhealthy,
-		"want ErrNetworkUnhealthy on pong timeout, got: %v", got)
-}
 
 // B1 — ErrServerClosed: server close frame path (component — mock transport)
 


### PR DESCRIPTION
## Summary

Remove redundant client-side ping mechanism. The Hub already pings every connected client; client-side ping doubles traffic and introduces a `pingInterval <= writeTimeout` configuration hazard. Dead-connection detection now relies entirely on the server-side heartbeat.

## Related issues

Closes #49
Relates to wspulse/.github#39

## Changes

- Remove exported `WithPingInterval` option and `ErrNetworkUnhealthy` sentinel error (breaking)
- Remove internal `pingPump` goroutine, `doPing` helper, `pingErrCh` channel, and `clientConfig.pingInterval` field
- Simplify `readPump` error prioritisation from `pingErr > writeErr > readErr` to `writeErr > readErr`
- Remove `NewTicker` from internal `clock` interface (only `NewTimer` for backoff remains)
- Clean up `fakeClock` ticker infrastructure and `mockTransport` ping fields in test helpers
- Delete 7 ping-related tests across 3 test files
- Add CHANGELOG entry under `[Unreleased]`

## Checklist

### Required

- [x] `make check` passes (`fmt` → `lint` → `test`)
- [x] Each commit represents exactly one logical change
- [x] Commit messages follow the format in `commit-message-instructions.md`
- [x] No unrelated code reformatting in this PR

### Conditional

- [x] Breaking change: major version bump discussed in linked issue
- [x] `Send` and `Close` remain safe for concurrent use