### PR TITLE
release: v0.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Replace `core.Transport` with a client-local `transport` interface; `Ping` is omitted
+  since dead-connection detection is server-side only. Requires `wspulse/core` v0.5.0+.
+
 ## [0.8.0] - 2026-04-16
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.8.1] - 2026-04-16
+
 ### Changed
 
 - Replace `core.Transport` with a client-local `transport` interface; `Ping` is omitted

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -149,7 +149,8 @@
 - Orphaned callback goroutines on disconnect — all goroutines cleaned up on `Close`
 - `Close()` waits for all internal goroutines to exit before returning
 
-[Unreleased]: https://github.com/wspulse/client-go/compare/v0.8.0...HEAD
+[Unreleased]: https://github.com/wspulse/client-go/compare/v0.8.1...HEAD
+[0.8.1]: https://github.com/wspulse/client-go/compare/v0.8.0...v0.8.1
 [0.8.0]: https://github.com/wspulse/client-go/compare/v0.7.0...v0.8.0
 [0.7.0]: https://github.com/wspulse/client-go/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/wspulse/client-go/compare/v0.5.1...v0.6.0

--- a/client.go
+++ b/client.go
@@ -202,12 +202,12 @@ func (c *internalClient) Done() <-chan struct{} { return c.done }
 // ── internal ──────────────────────────────────────────────────────────────────
 
 func (c *internalClient) dialOnce(ctx context.Context) error {
-	transport, err := c.dialer.Dial(ctx, c.url, c.config.dialHeaders)
+	trans, err := c.dialer.Dial(ctx, c.url, c.config.dialHeaders)
 	if err != nil {
 		return err
 	}
 	c.mu.Lock()
-	c.connection = transport
+	c.connection = trans
 	c.mu.Unlock()
 	return nil
 }

--- a/client.go
+++ b/client.go
@@ -212,7 +212,7 @@ func (c *internalClient) dialOnce(ctx context.Context) error {
 	return nil
 }
 
-func (c *internalClient) readPump(ctx context.Context, transport transport, dropped chan struct{}, writeErrCh <-chan error) {
+func (c *internalClient) readPump(ctx context.Context, trans transport, dropped chan struct{}, writeErrCh <-chan error) {
 
 	var readErr error
 
@@ -242,7 +242,7 @@ func (c *internalClient) readPump(ctx context.Context, transport transport, drop
 		select {
 		case <-c.done:
 		default:
-			_ = transport.CloseNow()
+			_ = trans.CloseNow()
 		}
 
 		// Determine the root-cause error for onTransportDrop:
@@ -271,11 +271,11 @@ func (c *internalClient) readPump(ctx context.Context, transport transport, drop
 	}()
 
 	if c.config.maxMessageSize > 0 {
-		transport.SetReadLimit(c.config.maxMessageSize)
+		trans.SetReadLimit(c.config.maxMessageSize)
 	}
 
 	for {
-		_, data, err := transport.Read(ctx)
+		_, data, err := trans.Read(ctx)
 		if err != nil {
 			readErr = err
 			return
@@ -293,10 +293,10 @@ func (c *internalClient) readPump(ctx context.Context, transport transport, drop
 	}
 }
 
-func (c *internalClient) writePump(ctx context.Context, transport transport, pumpDone chan struct{}, writeErrCh chan<- error) {
+func (c *internalClient) writePump(ctx context.Context, trans transport, pumpDone chan struct{}, writeErrCh chan<- error) {
 
 	defer func() {
-		_ = transport.CloseNow()
+		_ = trans.CloseNow()
 		close(pumpDone)
 	}()
 
@@ -305,7 +305,7 @@ func (c *internalClient) writePump(ctx context.Context, transport transport, pum
 		// writePump can take over on a fresh connection.
 		select {
 		case <-ctx.Done():
-			c.closeOrForce(transport)
+			c.closeOrForce(trans)
 			return
 		default:
 		}
@@ -314,7 +314,7 @@ func (c *internalClient) writePump(ctx context.Context, transport transport, pum
 		select {
 		case <-c.done:
 			c.logger.Debug("wspulse: writePump stopping (client closed)")
-			c.gracefulClose(transport)
+			c.gracefulClose(trans)
 			return
 		default:
 		}
@@ -322,7 +322,7 @@ func (c *internalClient) writePump(ctx context.Context, transport transport, pum
 		select {
 		case data := <-c.send:
 			writeCtx, cancel := context.WithTimeout(ctx, c.config.writeTimeout)
-			err := transport.Write(writeCtx, c.config.codec.FrameType(), data)
+			err := trans.Write(writeCtx, c.config.codec.FrameType(), data)
 			cancel()
 			if err != nil {
 				c.logger.Warn("wspulse: write failed",
@@ -338,11 +338,11 @@ func (c *internalClient) writePump(ctx context.Context, transport transport, pum
 
 		case <-c.done:
 			c.logger.Debug("wspulse: writePump stopping (client closed)")
-			c.gracefulClose(transport)
+			c.gracefulClose(trans)
 			return
 
 		case <-ctx.Done():
-			c.closeOrForce(transport)
+			c.closeOrForce(trans)
 			return
 		}
 	}
@@ -351,11 +351,11 @@ func (c *internalClient) writePump(ctx context.Context, transport transport, pum
 // closeOrForce sends a close frame if the client is shutting down, or
 // returns immediately if yielding for reconnect. In both cases the
 // deferred CloseNow() in writePump guarantees the transport is released.
-func (c *internalClient) closeOrForce(transport transport) {
+func (c *internalClient) closeOrForce(trans transport) {
 	select {
 	case <-c.done:
 		c.logger.Debug("wspulse: writePump stopping (client closed)")
-		c.gracefulClose(transport)
+		c.gracefulClose(trans)
 	default:
 		c.logger.Debug("wspulse: writePump yielding for reconnect")
 	}
@@ -369,10 +369,10 @@ func (c *internalClient) closeOrForce(transport transport) {
 // goroutine with a timer fallback. The goroutine is added to
 // goroutineWaitGroup so Close() does not return until it exits — even
 // when the timer fires and CloseNow() is called first.
-func (c *internalClient) gracefulClose(transport transport) {
+func (c *internalClient) gracefulClose(trans transport) {
 	done := make(chan struct{})
 	c.goroutineWaitGroup.Go(func() {
-		_ = transport.Close(wspulse.StatusNormalClosure, "")
+		_ = trans.Close(wspulse.StatusNormalClosure, "")
 		close(done)
 	})
 	t := time.NewTimer(c.config.writeTimeout)
@@ -381,7 +381,7 @@ func (c *internalClient) gracefulClose(transport transport) {
 	case <-done:
 	case <-t.C:
 		c.logger.Warn("wspulse: close frame timed out, forcing close")
-		_ = transport.CloseNow()
+		_ = trans.CloseNow()
 	}
 }
 

--- a/client.go
+++ b/client.go
@@ -62,7 +62,7 @@ type internalClient struct {
 	logger             *zap.Logger
 	dialer             dialer
 	clock              clock
-	connection         wspulse.Transport
+	connection         transport
 	send               chan []byte
 	done               chan struct{}      // closed via once.Do on permanent disconnect
 	quit               chan struct{}      // closed together with done via once.Do
@@ -212,7 +212,7 @@ func (c *internalClient) dialOnce(ctx context.Context) error {
 	return nil
 }
 
-func (c *internalClient) readPump(ctx context.Context, transport wspulse.Transport, dropped chan struct{}, writeErrCh <-chan error) {
+func (c *internalClient) readPump(ctx context.Context, transport transport, dropped chan struct{}, writeErrCh <-chan error) {
 
 	var readErr error
 
@@ -293,7 +293,7 @@ func (c *internalClient) readPump(ctx context.Context, transport wspulse.Transpo
 	}
 }
 
-func (c *internalClient) writePump(ctx context.Context, transport wspulse.Transport, pumpDone chan struct{}, writeErrCh chan<- error) {
+func (c *internalClient) writePump(ctx context.Context, transport transport, pumpDone chan struct{}, writeErrCh chan<- error) {
 
 	defer func() {
 		_ = transport.CloseNow()
@@ -351,7 +351,7 @@ func (c *internalClient) writePump(ctx context.Context, transport wspulse.Transp
 // closeOrForce sends a close frame if the client is shutting down, or
 // returns immediately if yielding for reconnect. In both cases the
 // deferred CloseNow() in writePump guarantees the transport is released.
-func (c *internalClient) closeOrForce(transport wspulse.Transport) {
+func (c *internalClient) closeOrForce(transport transport) {
 	select {
 	case <-c.done:
 		c.logger.Debug("wspulse: writePump stopping (client closed)")
@@ -369,7 +369,7 @@ func (c *internalClient) closeOrForce(transport wspulse.Transport) {
 // goroutine with a timer fallback. The goroutine is added to
 // goroutineWaitGroup so Close() does not return until it exits — even
 // when the timer fires and CloseNow() is called first.
-func (c *internalClient) gracefulClose(transport wspulse.Transport) {
+func (c *internalClient) gracefulClose(transport transport) {
 	done := make(chan struct{})
 	c.goroutineWaitGroup.Go(func() {
 		_ = transport.Close(wspulse.StatusNormalClosure, "")

--- a/dialer.go
+++ b/dialer.go
@@ -5,19 +5,17 @@ import (
 	"net/http"
 
 	"github.com/coder/websocket"
-
-	wspulse "github.com/wspulse/core"
 )
 
 // dialer abstracts the WebSocket dial operation for testability.
 type dialer interface {
-	Dial(ctx context.Context, url string, requestHeader http.Header) (wspulse.Transport, error)
+	Dial(ctx context.Context, url string, requestHeader http.Header) (transport, error)
 }
 
 // coderDialer uses github.com/coder/websocket.
 type coderDialer struct{}
 
-func (coderDialer) Dial(ctx context.Context, url string, requestHeader http.Header) (wspulse.Transport, error) {
+func (coderDialer) Dial(ctx context.Context, url string, requestHeader http.Header) (transport, error) {
 	conn, resp, err := websocket.Dial(ctx, url, &websocket.DialOptions{
 		HTTPHeader: requestHeader,
 	})

--- a/export_test.go
+++ b/export_test.go
@@ -21,6 +21,9 @@ func WithClock(c Clock) ClientOption {
 	return func(cfg *clientConfig) { cfg.clock = c }
 }
 
+// Transport exports the internal transport interface for testing only.
+type Transport = transport
+
 // Dialer exports the internal dialer interface for testing only.
 type Dialer = dialer
 

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.26.0
 require (
 	github.com/coder/websocket v1.8.14
 	github.com/stretchr/testify v1.11.1
-	github.com/wspulse/core v0.4.0
+	github.com/wspulse/core v0.5.0
 	go.uber.org/goleak v1.3.0
 	go.uber.org/zap v1.27.1
 )

--- a/go.sum
+++ b/go.sum
@@ -10,8 +10,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
-github.com/wspulse/core v0.4.0 h1:ZYQSGPu1invHlD2iIfzqeHWu4eck6eBGqH4PCdFSIsk=
-github.com/wspulse/core v0.4.0/go.mod h1:ZJxv16MeEIcq9z3Wo2fmz3P+qSz3IA28nuoTYk8pYC0=
+github.com/wspulse/core v0.5.0 h1:6XOp0peQ5lASC68FLF5a4InPBwL9ZoBRQLjWkCnmFg0=
+github.com/wspulse/core v0.5.0/go.mod h1:ZJxv16MeEIcq9z3Wo2fmz3P+qSz3IA28nuoTYk8pYC0=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
 go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
 go.uber.org/multierr v1.10.0 h1:S0h4aNzvfcFsC3dRF1jLoaov7oRaKqRGC/pUEJ2yvPQ=

--- a/mock_transport_test.go
+++ b/mock_transport_test.go
@@ -259,5 +259,8 @@ func (d *mockDialer) CallCount() int {
 	return d.callCount
 }
 
+// Ensure mockTransport satisfies the exported Transport type alias.
+var _ client.Transport = (*mockTransport)(nil)
+
 // Ensure mockDialer satisfies the exported Dialer type alias.
 var _ client.Dialer = (*mockDialer)(nil)

--- a/mock_transport_test.go
+++ b/mock_transport_test.go
@@ -119,10 +119,6 @@ func (m *mockTransport) Write(ctx context.Context, typ wspulse.MessageType, data
 	}
 }
 
-func (m *mockTransport) Ping(_ context.Context) error {
-	return nil
-}
-
 func (m *mockTransport) SetReadLimit(limit int64) {
 	m.mu.Lock()
 	m.readLimit = limit
@@ -234,7 +230,7 @@ func newMockDialer(results ...mockDialResult) *mockDialer {
 	}
 }
 
-func (d *mockDialer) Dial(_ context.Context, _ string, _ http.Header) (wspulse.Transport, error) {
+func (d *mockDialer) Dial(_ context.Context, _ string, _ http.Header) (client.Transport, error) {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 	if d.callCount >= len(d.results) {

--- a/testhelpers_test.go
+++ b/testhelpers_test.go
@@ -123,7 +123,7 @@ type headerCapturingDialer struct {
 	called    atomic.Bool
 }
 
-func (d *headerCapturingDialer) Dial(_ context.Context, _ string, header http.Header) (wspulse.Transport, error) {
+func (d *headerCapturingDialer) Dial(_ context.Context, _ string, header http.Header) (client.Transport, error) {
 	if d.onDial != nil {
 		d.onDial(header)
 	}

--- a/transport.go
+++ b/transport.go
@@ -31,6 +31,8 @@ type coderTransport struct {
 	conn *websocket.Conn
 }
 
+var _ transport = (*coderTransport)(nil)
+
 func (t *coderTransport) Read(ctx context.Context) (wspulse.MessageType, []byte, error) {
 	typ, data, err := t.conn.Read(ctx)
 	if err != nil && websocket.CloseStatus(err) != -1 {

--- a/transport.go
+++ b/transport.go
@@ -8,13 +8,23 @@ import (
 	wspulse "github.com/wspulse/core"
 )
 
+// transport is the client-local WebSocket connection contract.
+// It omits Ping — dead-connection detection is server-side only (hub heartbeat).
+type transport interface {
+	Read(ctx context.Context) (wspulse.MessageType, []byte, error)
+	Write(ctx context.Context, typ wspulse.MessageType, data []byte) error
+	SetReadLimit(n int64)
+	Close(code wspulse.StatusCode, reason string) error
+	CloseNow() error
+}
+
 // Compile-time assertions: numeric values must match between coder/websocket
 // and wspulse/core (both follow RFC 6455). A mismatch here means frames
 // would be silently mis-typed at runtime.
 var _ = [1]struct{}{}[websocket.MessageText-websocket.MessageType(wspulse.TextMessage)]
 var _ = [1]struct{}{}[websocket.MessageBinary-websocket.MessageType(wspulse.BinaryMessage)]
 
-// coderTransport wraps *websocket.Conn to satisfy core.Transport.
+// coderTransport wraps *websocket.Conn to satisfy the local transport interface.
 // All type conversions are simple casts — numeric values are identical
 // between coder/websocket and wspulse/core (both follow RFC 6455).
 type coderTransport struct {
@@ -33,10 +43,6 @@ func (t *coderTransport) Read(ctx context.Context) (wspulse.MessageType, []byte,
 
 func (t *coderTransport) Write(ctx context.Context, typ wspulse.MessageType, data []byte) error {
 	return t.conn.Write(ctx, websocket.MessageType(typ), data)
-}
-
-func (t *coderTransport) Ping(ctx context.Context) error {
-	return t.conn.Ping(ctx)
 }
 
 func (t *coderTransport) SetReadLimit(n int64) {


### PR DESCRIPTION
## Summary

Release v0.8.1 — internal transport refactor, no public API changes.

## Changes

- CHANGELOG: promote `[Unreleased]` to `[0.8.1] - 2026-04-16`

## Checklist

### Required

- [x] `make check` passes (`fmt` → `lint` → `test`)
- [x] Each commit represents exactly one logical change
- [x] Commit messages follow the format in `commit-message-instructions.md`
- [x] No unrelated code reformatting in this PR