### PR TITLE
Rename Frame to Message, FrameType to WireType

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -2,7 +2,7 @@
 
 ## Project Overview
 
-wspulse/client-go is a **WebSocket client library for Go** with automatic reconnection and exponential backoff. Module path: `github.com/wspulse/client-go`. Package name: `client`. Depends on `github.com/wspulse/core` for shared types (`Frame`, `Codec`, `Transport`).
+wspulse/client-go is a **WebSocket client library for Go** with automatic reconnection and exponential backoff. Module path: `github.com/wspulse/client-go`. Package name: `client`. Depends on `github.com/wspulse/core` for shared types (`Message`, `Codec`, `Transport`).
 
 ## Architecture
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+### Changed
+
+- **BREAKING**: `Client.Send(f wspulse.Frame)` renamed to `Client.Send(m wspulse.Message)` — follows upstream core rename (`wspulse/.github#34`)
+- **BREAKING**: `WithOnMessage(fn func(wspulse.Frame))` renamed to `WithOnMessage(fn func(wspulse.Message))` — follows upstream core rename
+- `Codec.FrameType()` usage updated to `Codec.WireType()` — follows upstream core rename
+
 ## [0.8.1] - 2026-04-16
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A Go WebSocket client with optional automatic reconnection, designed for use wit
 ## Design Goals
 
 - Thin client: connect, send, receive, auto-reconnect
-- Matches server-side `Frame` and `Codec` types via [wspulse/core](https://github.com/wspulse/core)
+- Matches server-side `Message` and `Codec` types via [wspulse/core](https://github.com/wspulse/core)
 - Exponential backoff with configurable retries
 - Transport drop vs. permanent disconnect callbacks
 
@@ -37,7 +37,7 @@ import (
 )
 
 c, err := client.Dial("ws://localhost:8080/ws?room=r1&token=xyz",
-    client.WithOnMessage(func(f wspulse.Frame) {
+    client.WithOnMessage(func(f wspulse.Message) {
         fmt.Printf("[%s] %s\n", f.Event, f.Payload)
     }),
     client.WithAutoReconnect(5, time.Second, 30*time.Second),
@@ -47,15 +47,15 @@ if err != nil {
 }
 defer c.Close()
 
-c.Send(wspulse.Frame{Event: "msg", Payload: []byte(`{"text":"hello"}`)})
+c.Send(wspulse.Message{Event: "msg", Payload: []byte(`{"text":"hello"}`)})
 <-c.Done()
 ```
 
 ---
 
-## Frame Types and Server-Side Routing
+## Message Types and Server-Side Routing
 
-Every frame sent or received is a JSON object on the wire:
+Every message sent or received is a JSON object on the wire:
 
 ```json
 {
@@ -64,17 +64,17 @@ Every frame sent or received is a JSON object on the wire:
 }
 ```
 
-The `"event"` field is the routing key on the server. Set `frame.Event` to match the handler registered with `r.On("chat.message", ...)` on the server side. The `"payload"` field carries arbitrary JSON — the library does not inspect it.
+The `"event"` field is the routing key on the server. Set `msg.Event` to match the handler registered with `r.On("chat.message", ...)` on the server side. The `"payload"` field carries arbitrary JSON — the library does not inspect it.
 
 ```go
-// Send a typed frame — server routes by "event"
-c.Send(wspulse.Frame{
+// Send a typed message — server routes by "event"
+c.Send(wspulse.Message{
     Event:   "chat.message",
     Payload: []byte(`{"text":"hello world"}`),
 })
 
-// Receive typed frames
-client.WithOnMessage(func(f wspulse.Frame) {
+// Receive typed messages
+client.WithOnMessage(func(f wspulse.Message) {
     switch f.Event {
     case "chat.message":
         // handle message
@@ -99,14 +99,14 @@ rtr := router.New()
 rtr.Use(router.Recovery())
 
 rtr.On("chat.message", func(c *router.Context) {
-    fmt.Printf("[msg] %s\n", c.Frame.Payload)
+    fmt.Printf("[msg] %s\n", c.Message.Payload)
 })
 rtr.On("chat.welcome", func(c *router.Context) {
     fmt.Println("joined!")
 })
 
 c, _ := client.Dial("ws://localhost:8080/ws?room=r1&token=xyz",
-    client.WithOnMessage(func(f wspulse.Frame) {
+    client.WithOnMessage(func(f wspulse.Message) {
         rtr.Dispatch(nil, f) // no router.Connection on the client side
     }),
     client.WithAutoReconnect(5, time.Second, 30*time.Second),

--- a/basic_test.go
+++ b/basic_test.go
@@ -13,8 +13,8 @@ import (
 
 func TestSendAndReceive(t *testing.T) {
 	t.Parallel()
-	received := make(chan wspulse.Frame, 1)
-	c, mt, _ := dialWithMock(t, client.WithOnMessage(func(f wspulse.Frame) {
+	received := make(chan wspulse.Message, 1)
+	c, mt, _ := dialWithMock(t, client.WithOnMessage(func(f wspulse.Message) {
 		received <- f
 	}))
 	defer func() { _ = c.Close() }()
@@ -24,8 +24,8 @@ func TestSendAndReceive(t *testing.T) {
 	defer close(echoDone)
 	go echoLoop(mt, echoDone)
 
-	frame := wspulse.Frame{Event: "echo", Payload: []byte(`"hello"`)}
-	require.NoError(t, c.Send(frame), "Send failed")
+	msg := wspulse.Message{Event: "echo", Payload: []byte(`"hello"`)}
+	require.NoError(t, c.Send(msg), "Send failed")
 
 	f := requireReceive(t, received)
 	assert.Equal(t, "echo", f.Event)
@@ -42,7 +42,7 @@ func TestSend_AfterClose_ReturnsErrConnectionClosed(t *testing.T) {
 	t.Parallel()
 	c, _, _ := dialWithMock(t)
 	_ = c.Close()
-	sendErr := c.Send(wspulse.Frame{Event: "msg"})
+	sendErr := c.Send(wspulse.Message{Event: "msg"})
 	assert.ErrorIs(t, sendErr, wspulse.ErrConnectionClosed)
 }
 
@@ -58,25 +58,25 @@ func TestSend_WritesCorrectData(t *testing.T) {
 	c, mt, _ := dialWithMock(t)
 	t.Cleanup(func() { _ = c.Close() })
 
-	frame := wspulse.Frame{Event: "test", Payload: []byte(`"data"`)}
-	require.NoError(t, c.Send(frame), "Send failed")
+	msg := wspulse.Message{Event: "test", Payload: []byte(`"data"`)}
+	require.NoError(t, c.Send(msg), "Send failed")
 
 	w := requireReceive(t, mt.writeCh)
 	assert.Equal(t, wspulse.TextMessage, w.messageType, "messageType")
 
 	// Decode the written data and verify.
-	var wireFrame struct {
+	var wireMsg struct {
 		Event   string          `json:"event"`
 		Payload json.RawMessage `json:"payload"`
 	}
-	require.NoError(t, json.Unmarshal(w.data, &wireFrame), "unmarshal written data")
-	assert.Equal(t, "test", wireFrame.Event)
+	require.NoError(t, json.Unmarshal(w.data, &wireMsg), "unmarshal written data")
+	assert.Equal(t, "test", wireMsg.Event)
 }
 
 func TestClose_DiscardsBufferedFrames(t *testing.T) {
 	t.Parallel()
-	// Contract: close() discards unsent buffered frames. After Close(),
-	// writePump must write at most 1 data frame (the one in-flight when
+	// Contract: close() discards unsent buffered messages. After Close(),
+	// writePump must write at most 1 data message (the one in-flight when
 	// c.done fires) before stopping.
 	const bufSize = 8
 	mt := newMockTransport()
@@ -96,13 +96,13 @@ func TestClose_DiscardsBufferedFrames(t *testing.T) {
 		_ = c.Close()
 	})
 
-	// Send one frame — writePump picks it from c.send and blocks in Write.
-	require.NoError(t, c.Send(wspulse.Frame{Event: "first"}))
+	// Send one message — writePump picks it from c.send and blocks in Write.
+	require.NoError(t, c.Send(wspulse.Message{Event: "first"}))
 	<-mt.writeEntered // writePump is now blocked in Write
 
-	// Fill the remaining buffer — these frames sit in c.send.
+	// Fill the remaining buffer — these messages sit in c.send.
 	for i := 0; i < bufSize-1; i++ {
-		require.NoError(t, c.Send(wspulse.Frame{Event: "buffered"}))
+		require.NoError(t, c.Send(wspulse.Message{Event: "buffered"}))
 	}
 
 	// Close in a goroutine — c.done closes immediately, then waits for goroutines.
@@ -115,24 +115,24 @@ func TestClose_DiscardsBufferedFrames(t *testing.T) {
 	unblock()
 	require.NoError(t, <-closeDone)
 
-	// Count data frames written to the transport.
+	// Count data messages written to the transport.
 	writes := mt.DrainWrites()
-	dataFrames := 0
+	dataMessages := 0
 	for _, w := range writes {
 		if w.messageType == wspulse.TextMessage {
-			dataFrames++
+			dataMessages++
 		}
 	}
-	// Priority check guarantees at most 1 data frame (the in-flight one).
-	// The remaining 7 frames in c.send are discarded.
-	require.LessOrEqual(t, dataFrames, 1,
-		"expected at most 1 data frame (in-flight), got %d", dataFrames)
+	// Priority check guarantees at most 1 data message (the in-flight one).
+	// The remaining 7 messages in c.send are discarded.
+	require.LessOrEqual(t, dataMessages, 1,
+		"expected at most 1 data message (in-flight), got %d", dataMessages)
 }
 
 func TestNormalCloseFrame(t *testing.T) {
 	t.Parallel()
-	// When the client calls Close(), writePump should send a WebSocket close
-	// frame with StatusNormalClosure before exiting.
+	// When the client calls Close(), writePump should send a WebSocket close message
+	// with StatusNormalClosure before exiting.
 	mt := newMockTransport()
 	mt.closeCalled = make(chan closeCall, 1)
 	fc := newFakeClock()

--- a/basic_test.go
+++ b/basic_test.go
@@ -73,7 +73,7 @@ func TestSend_WritesCorrectData(t *testing.T) {
 	assert.Equal(t, "test", wireMsg.Event)
 }
 
-func TestClose_DiscardsBufferedFrames(t *testing.T) {
+func TestClose_DiscardsBufferedMessages(t *testing.T) {
 	t.Parallel()
 	// Contract: close() discards unsent buffered messages. After Close(),
 	// writePump must write at most 1 data message (the one in-flight when
@@ -131,7 +131,7 @@ func TestClose_DiscardsBufferedFrames(t *testing.T) {
 
 func TestNormalCloseFrame(t *testing.T) {
 	t.Parallel()
-	// When the client calls Close(), writePump should send a WebSocket close message
+	// When the client calls Close(), writePump should send a WebSocket close frame
 	// with StatusNormalClosure before exiting.
 	mt := newMockTransport()
 	mt.closeCalled = make(chan closeCall, 1)

--- a/callback_test.go
+++ b/callback_test.go
@@ -130,7 +130,7 @@ func TestClose_OnDisconnectFiresExactlyOnce(t *testing.T) {
 			disconnectCount++
 			mu.Unlock()
 		}),
-		client.WithOnMessage(func(f wspulse.Frame) {
+		client.WithOnMessage(func(f wspulse.Message) {
 			select {
 			case received <- struct{}{}:
 			default:
@@ -144,8 +144,8 @@ func TestClose_OnDisconnectFiresExactlyOnce(t *testing.T) {
 	defer close(echoDone)
 	go echoLoop(mt, echoDone)
 
-	// Confirm connection is established by round-tripping a frame.
-	require.NoError(t, c.Send(wspulse.Frame{Event: "ping", Payload: []byte(`"1"`)}), "Send failed")
+	// Confirm connection is established by round-tripping a message.
+	require.NoError(t, c.Send(wspulse.Message{Event: "ping", Payload: []byte(`"1"`)}), "Send failed")
 	requireReceive(t, received)
 
 	_ = c.Close()
@@ -226,9 +226,9 @@ func TestOnTransportDrop_WritePumpDataWriteError(t *testing.T) {
 	)
 	t.Cleanup(func() { _ = c.Close() })
 
-	// Inject write error, then send a frame to trigger writePump's data path.
+	// Inject write error, then send a message to trigger writePump's data path.
 	mt.SetWriteError(writeErr)
-	_ = c.Send(wspulse.Frame{Event: "ping"})
+	_ = c.Send(wspulse.Message{Event: "ping"})
 
 	got := requireReceive(t, transportDropErr)
 	assert.ErrorIs(t, got, writeErr, "onTransportDrop should receive the write error, not a read-side error")
@@ -272,12 +272,12 @@ func TestOnTransportDrop_ReadError_NotOverriddenByCloseInducedWriteError(t *test
 	require.NoError(t, err, "Dial failed")
 	t.Cleanup(func() { _ = c.Close() })
 
-	// Block writes and send a frame so writePump enters Write and blocks.
+	// Block writes and send a message so writePump enters Write and blocks.
 	rawUnblock := mt.BlockWrites()
 	var unblockOnce sync.Once
 	unblock := func() { unblockOnce.Do(rawUnblock) }
 	defer unblock()
-	require.NoError(t, c.Send(wspulse.Frame{Event: "trigger"}))
+	require.NoError(t, c.Send(wspulse.Message{Event: "trigger"}))
 	<-mt.writeEntered // writePump is now blocked mid-Write
 
 	closeStarted := make(chan struct{})
@@ -337,7 +337,7 @@ func TestOnTransportDrop_WriteError_Reconnect_CleanCycle(t *testing.T) {
 
 	// First cycle: trigger write error on mt1.
 	mt1.SetWriteError(writeErr)
-	_ = c.Send(wspulse.Frame{Event: "trigger"})
+	_ = c.Send(wspulse.Message{Event: "trigger"})
 
 	got1 := requireReceive(t, transportDropErrs)
 	assert.ErrorIs(t, got1, writeErr, "first drop should report write error")
@@ -400,7 +400,7 @@ func TestOnTransportRestore_FiresAfterReconnect(t *testing.T) {
 
 	transportDropped := make(chan struct{}, 5)
 	transportRestored := make(chan struct{}, 5)
-	received := make(chan wspulse.Frame, 5)
+	received := make(chan wspulse.Message, 5)
 	c, err := client.Dial("ws://mock",
 		client.WithDialer(md),
 		client.WithClock(fc),
@@ -417,7 +417,7 @@ func TestOnTransportRestore_FiresAfterReconnect(t *testing.T) {
 			default:
 			}
 		}),
-		client.WithOnMessage(func(f wspulse.Frame) {
+		client.WithOnMessage(func(f wspulse.Message) {
 			select {
 			case received <- f:
 			default:
@@ -453,7 +453,7 @@ func TestOnTransportRestore_FiresAfterReconnect(t *testing.T) {
 	go echoLoop(mt2, echoDone)
 
 	// Verify message delivery works after restore.
-	require.NoError(t, c.Send(wspulse.Frame{Event: "post-restore", Payload: []byte(`"ok"`)}), "Send after restore")
+	require.NoError(t, c.Send(wspulse.Message{Event: "post-restore", Payload: []byte(`"ok"`)}), "Send after restore")
 	select {
 	case f := <-received:
 		assert.Equal(t, "post-restore", f.Event)
@@ -465,13 +465,13 @@ func TestOnTransportRestore_FiresAfterReconnect(t *testing.T) {
 func TestOnTransportRestore_DoesNotFireOnInitialConnect(t *testing.T) {
 	t.Parallel()
 	var restoreCount atomic.Int32
-	received := make(chan wspulse.Frame, 1)
+	received := make(chan wspulse.Message, 1)
 
 	c, mt, _ := dialWithMock(t,
 		client.WithOnTransportRestore(func() {
 			restoreCount.Add(1)
 		}),
-		client.WithOnMessage(func(f wspulse.Frame) {
+		client.WithOnMessage(func(f wspulse.Message) {
 			select {
 			case received <- f:
 			default:
@@ -485,8 +485,8 @@ func TestOnTransportRestore_DoesNotFireOnInitialConnect(t *testing.T) {
 	defer close(echoDone)
 	go echoLoop(mt, echoDone)
 
-	// Round-trip a frame to prove all pumps are fully operational.
-	require.NoError(t, c.Send(wspulse.Frame{Event: "probe"}), "Send failed")
+	// Round-trip a message to prove all pumps are fully operational.
+	require.NoError(t, c.Send(wspulse.Message{Event: "probe"}), "Send failed")
 	requireReceive(t, received)
 
 	assert.Equal(t, int32(0), restoreCount.Load(), "onTransportRestore should not fire on initial connect")

--- a/client.go
+++ b/client.go
@@ -29,8 +29,8 @@ var ErrServerClosed = errors.New("wspulse: server closed connection")
 
 // Client is the public interface for the WebSocket client.
 type Client interface {
-	// Send enqueues f for delivery to the server.
-	Send(f wspulse.Frame) error
+	// Send enqueues m for delivery to the server.
+	Send(m wspulse.Message) error
 
 	// Close terminates the connection and stops any reconnect loop.
 	Close() error
@@ -149,15 +149,15 @@ func Dial(urlStr string, opts ...ClientOption) (Client, error) {
 
 var _ Client = (*internalClient)(nil)
 
-// Send enqueues f for delivery to the server.
-func (c *internalClient) Send(f wspulse.Frame) error {
+// Send enqueues m for delivery to the server.
+func (c *internalClient) Send(m wspulse.Message) error {
 	select {
 	case <-c.done:
 		return wspulse.ErrConnectionClosed
 	default:
 	}
 
-	data, err := c.config.codec.Encode(f)
+	data, err := c.config.codec.Encode(m)
 	if err != nil {
 		return err
 	}
@@ -281,11 +281,11 @@ func (c *internalClient) readPump(ctx context.Context, trans transport, dropped 
 			return
 		}
 		if fn := c.config.onMessage; fn != nil {
-			frame, decodeErr := c.config.codec.Decode(data)
+			msg, decodeErr := c.config.codec.Decode(data)
 			if decodeErr == nil {
-				fn(frame)
+				fn(msg)
 			} else {
-				c.logger.Warn("wspulse: decode failed, frame dropped",
+				c.logger.Warn("wspulse: decode failed, message dropped",
 					zap.Error(decodeErr),
 				)
 			}
@@ -310,7 +310,7 @@ func (c *internalClient) writePump(ctx context.Context, trans transport, pumpDon
 		default:
 		}
 
-		// Close priority check — discard buffered frames on shutdown.
+		// Close priority check — discard buffered messages on shutdown.
 		select {
 		case <-c.done:
 			c.logger.Debug("wspulse: writePump stopping (client closed)")
@@ -322,7 +322,7 @@ func (c *internalClient) writePump(ctx context.Context, trans transport, pumpDon
 		select {
 		case data := <-c.send:
 			writeCtx, cancel := context.WithTimeout(ctx, c.config.writeTimeout)
-			err := trans.Write(writeCtx, c.config.codec.FrameType(), data)
+			err := trans.Write(writeCtx, c.config.codec.WireType(), data)
 			cancel()
 			if err != nil {
 				c.logger.Warn("wspulse: write failed",

--- a/client_test.go
+++ b/client_test.go
@@ -187,7 +187,7 @@ func TestClient_CallbackOptions_Valid_NoPanic(t *testing.T) {
 	// Verify that callback-related option builders accept valid callbacks
 	// without panicking and always return non-nil ClientOption values.
 	opts := []client.ClientOption{
-		client.WithOnMessage(func(f wspulse.Frame) {}),
+		client.WithOnMessage(func(f wspulse.Message) {}),
 		client.WithOnDisconnect(func(err error) {}),
 		client.WithOnTransportDrop(func(err error) {}),
 		client.WithOnTransportRestore(func() {}),

--- a/doc/component-tests.md
+++ b/doc/component-tests.md
@@ -31,7 +31,7 @@ deterministic and run with `make check`.
 | `TestSend_WritesCorrectData`               | Encoded message arrives at transport with correct payload |
 | `TestClose_SafeToCallTwice`                | `Close()` is safe to call multiple times               |
 | `TestDone_ClosedAfterClose`                | `Done()` channel closes after `Close()`                |
-| `TestNormalCloseFrame`                     | `Close()` sends a WebSocket close message              |
+| `TestNormalCloseFrame`                     | `Close()` sends a WebSocket close frame                |
 
 ### callback_test.go
 
@@ -71,7 +71,7 @@ deterministic and run with `make check`.
 | -------------------------------------------------- | ------------------------------------------------------------- |
 | `TestSend_BufferFull_ReturnsErrSendBufferFull`     | `Send()` returns `ErrSendBufferFull` when buffer is saturated |
 | `TestSend_CustomBufferSize_Applied`                | `WithSendBufferSize` sets the channel capacity                |
-| `TestReadPump_DecodeFailure_DropsFrame`            | Malformed message is dropped; connection continues              |
+| `TestReadPump_DecodeFailure_DropsMessage`           | Malformed message is dropped; connection continues              |
 | `TestSend_EncodeError_ReturnsError`                | `Send()` propagates codec encode errors                       |
 | `TestReadPump_PanicRecovery`                       | Panic inside `onMessage` is recovered gracefully              |
 | `TestWithDialHeaders`                              | Custom dial headers are forwarded to the dialer               |

--- a/doc/component-tests.md
+++ b/doc/component-tests.md
@@ -28,10 +28,10 @@ deterministic and run with `make check`.
 
 | Test Name                                  | What It Covers                                         |
 | ------------------------------------------ | ------------------------------------------------------ |
-| `TestSend_WritesCorrectData`               | Encoded frame arrives at transport with correct payload |
+| `TestSend_WritesCorrectData`               | Encoded message arrives at transport with correct payload |
 | `TestClose_SafeToCallTwice`                | `Close()` is safe to call multiple times               |
 | `TestDone_ClosedAfterClose`                | `Done()` channel closes after `Close()`                |
-| `TestNormalCloseFrame`                     | `Close()` sends a WebSocket close frame                |
+| `TestNormalCloseFrame`                     | `Close()` sends a WebSocket close message              |
 
 ### callback_test.go
 
@@ -71,7 +71,7 @@ deterministic and run with `make check`.
 | -------------------------------------------------- | ------------------------------------------------------------- |
 | `TestSend_BufferFull_ReturnsErrSendBufferFull`     | `Send()` returns `ErrSendBufferFull` when buffer is saturated |
 | `TestSend_CustomBufferSize_Applied`                | `WithSendBufferSize` sets the channel capacity                |
-| `TestReadPump_DecodeFailure_DropsFrame`            | Malformed frame is dropped; connection continues              |
+| `TestReadPump_DecodeFailure_DropsFrame`            | Malformed message is dropped; connection continues              |
 | `TestSend_EncodeError_ReturnsError`                | `Send()` propagates codec encode errors                       |
 | `TestReadPump_PanicRecovery`                       | Panic inside `onMessage` is recovered gracefully              |
 | `TestWithDialHeaders`                              | Custom dial headers are forwarded to the dialer               |

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.26.0
 require (
 	github.com/coder/websocket v1.8.14
 	github.com/stretchr/testify v1.11.1
-	github.com/wspulse/core v0.5.0
+	github.com/wspulse/core v0.6.0
 	go.uber.org/goleak v1.3.0
 	go.uber.org/zap v1.27.1
 )

--- a/go.sum
+++ b/go.sum
@@ -10,8 +10,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
-github.com/wspulse/core v0.5.0 h1:6XOp0peQ5lASC68FLF5a4InPBwL9ZoBRQLjWkCnmFg0=
-github.com/wspulse/core v0.5.0/go.mod h1:ZJxv16MeEIcq9z3Wo2fmz3P+qSz3IA28nuoTYk8pYC0=
+github.com/wspulse/core v0.6.0 h1:eU+xYnEAu2hqvLPIrwxTYyXCFz7GHweqKwh0klxh/k0=
+github.com/wspulse/core v0.6.0/go.mod h1:ZJxv16MeEIcq9z3Wo2fmz3P+qSz3IA28nuoTYk8pYC0=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
 go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
 go.uber.org/multierr v1.10.0 h1:S0h4aNzvfcFsC3dRF1jLoaov7oRaKqRGC/pUEJ2yvPQ=

--- a/lifecycle_test.go
+++ b/lifecycle_test.go
@@ -152,9 +152,9 @@ func TestClose_WaitsForGoroutines_AutoReconnect(t *testing.T) {
 
 func TestDone_FiresOnServerDrop(t *testing.T) {
 	t.Parallel()
-	received := make(chan wspulse.Frame, 1)
+	received := make(chan wspulse.Message, 1)
 	c, mt, _ := dialWithMock(t,
-		client.WithOnMessage(func(f wspulse.Frame) {
+		client.WithOnMessage(func(f wspulse.Message) {
 			received <- f
 		}),
 	)
@@ -164,8 +164,8 @@ func TestDone_FiresOnServerDrop(t *testing.T) {
 	echoDone := make(chan struct{})
 	go echoLoop(mt, echoDone)
 
-	// Confirm the connection is established by round-tripping a frame.
-	require.NoError(t, c.Send(wspulse.Frame{Event: "ping", Payload: []byte(`"1"`)}), "Send failed")
+	// Confirm the connection is established by round-tripping a message.
+	require.NoError(t, c.Send(wspulse.Message{Event: "ping", Payload: []byte(`"1"`)}), "Send failed")
 	requireReceive(t, received)
 
 	// Stop echo and simulate server drop.
@@ -173,7 +173,7 @@ func TestDone_FiresOnServerDrop(t *testing.T) {
 	mt.InjectError(&net.OpError{Op: "read", Err: errors.New("connection reset")})
 
 	requireDone(t, c)
-	assert.ErrorIs(t, c.Send(wspulse.Frame{Event: "msg"}), wspulse.ErrConnectionClosed)
+	assert.ErrorIs(t, c.Send(wspulse.Message{Event: "msg"}), wspulse.ErrConnectionClosed)
 }
 
 func TestConcurrentSendAndClose_NoRace(t *testing.T) {
@@ -189,7 +189,7 @@ func TestConcurrentSendAndClose_NoRace(t *testing.T) {
 			defer wg.Done()
 			started <- struct{}{}
 			for j := 0; j < 50; j++ {
-				_ = c.Send(wspulse.Frame{Event: "msg", Payload: []byte(`"x"`)})
+				_ = c.Send(wspulse.Message{Event: "msg", Payload: []byte(`"x"`)})
 			}
 		}()
 	}
@@ -221,7 +221,7 @@ func TestConcurrentCloseAndTransportDrop_OnDisconnectExactlyOnce(t *testing.T) {
 			default:
 			}
 		}),
-		client.WithOnMessage(func(f wspulse.Frame) {
+		client.WithOnMessage(func(f wspulse.Message) {
 			select {
 			case received <- struct{}{}:
 			default:
@@ -236,8 +236,8 @@ func TestConcurrentCloseAndTransportDrop_OnDisconnectExactlyOnce(t *testing.T) {
 	defer close(echoDone)
 	go echoLoop(mt, echoDone)
 
-	// Confirm the connection is established by round-tripping a frame.
-	require.NoError(t, c.Send(wspulse.Frame{Event: "ping", Payload: []byte(`"1"`)}), "Send failed")
+	// Confirm the connection is established by round-tripping a message.
+	require.NoError(t, c.Send(wspulse.Message{Event: "ping", Payload: []byte(`"1"`)}), "Send failed")
 	requireReceive(t, received)
 
 	// Simultaneously close the client and drop the transport.

--- a/misc_test.go
+++ b/misc_test.go
@@ -58,7 +58,7 @@ func TestSend_CustomBufferSize_Applied(t *testing.T) {
 	assert.Equal(t, bufSize, client.SendBufferCap(c), "SendBufferCap")
 }
 
-func TestReadPump_DecodeFailure_DropsFrame(t *testing.T) {
+func TestReadPump_DecodeFailure_DropsMessage(t *testing.T) {
 	t.Parallel()
 	received := make(chan wspulse.Message, 5)
 	c, mt, _ := dialWithMock(t,

--- a/misc_test.go
+++ b/misc_test.go
@@ -37,7 +37,7 @@ func TestSend_BufferFull_ReturnsErrSendBufferFull(t *testing.T) {
 
 	sawFull := false
 	for i := 0; i < 100; i++ {
-		err := c.Send(wspulse.Frame{Event: "flood", Payload: []byte(`"x"`)})
+		err := c.Send(wspulse.Message{Event: "flood", Payload: []byte(`"x"`)})
 		if errors.Is(err, wspulse.ErrSendBufferFull) {
 			sawFull = true
 			break
@@ -60,19 +60,19 @@ func TestSend_CustomBufferSize_Applied(t *testing.T) {
 
 func TestReadPump_DecodeFailure_DropsFrame(t *testing.T) {
 	t.Parallel()
-	received := make(chan wspulse.Frame, 5)
+	received := make(chan wspulse.Message, 5)
 	c, mt, _ := dialWithMock(t,
-		client.WithOnMessage(func(f wspulse.Frame) {
+		client.WithOnMessage(func(f wspulse.Message) {
 			received <- f
 		}),
 	)
 	t.Cleanup(func() { _ = c.Close() })
 
-	// Inject an invalid JSON frame (decode failure — should be dropped).
+	// Inject an invalid JSON message (decode failure — should be dropped).
 	mt.InjectMessage(wspulse.TextMessage, []byte("not valid json{{{"))
-	// Inject a valid frame that should be delivered.
-	validFrame := `{"event":"valid-frame","payload":"ok"}`
-	mt.InjectMessage(wspulse.TextMessage, []byte(validFrame))
+	// Inject a valid message that should be delivered.
+	validMsg := `{"event":"valid-frame","payload":"ok"}`
+	mt.InjectMessage(wspulse.TextMessage, []byte(validMsg))
 
 	f := requireReceive(t, received)
 	assert.Equal(t, "valid-frame", f.Event)
@@ -82,7 +82,7 @@ func TestReadPump_PanicRecovery(t *testing.T) {
 	t.Parallel()
 	disconnected := make(chan error, 1)
 	c, mt, _ := dialWithMock(t,
-		client.WithOnMessage(func(f wspulse.Frame) {
+		client.WithOnMessage(func(f wspulse.Message) {
 			panic("boom")
 		}),
 		client.WithOnDisconnect(func(err error) {
@@ -91,7 +91,7 @@ func TestReadPump_PanicRecovery(t *testing.T) {
 	)
 	t.Cleanup(func() { _ = c.Close() })
 
-	// Inject a valid frame to trigger the panic in OnMessage.
+	// Inject a valid message to trigger the panic in OnMessage.
 	trigger := `{"event":"trigger","payload":null}`
 	mt.InjectMessage(wspulse.TextMessage, []byte(trigger))
 
@@ -112,7 +112,7 @@ func TestSend_EncodeError_ReturnsError(t *testing.T) {
 	require.NoError(t, err, "Dial failed")
 	t.Cleanup(func() { _ = c.Close() })
 
-	err = c.Send(wspulse.Frame{Event: "msg"})
+	err = c.Send(wspulse.Message{Event: "msg"})
 	require.Error(t, err, "expected encode error")
 }
 

--- a/options.go
+++ b/options.go
@@ -12,19 +12,19 @@ import (
 
 // Configuration upper bounds — option functions panic if these ceilings are exceeded.
 const (
-	maxWriteTimeout  = 30 * time.Second // WithWriteTimeout upper bound
-	maxMsgSizeBytes  = 64 << 20         // WithMaxMessageSize upper bound — 64 MiB
-	maxBaseDelay     = 1 * time.Minute  // WithAutoReconnect: baseDelay upper bound
-	maxDelayLimit    = 5 * time.Minute  // WithAutoReconnect: maxDelay upper bound
-	maxRetriesLimit  = 32               // WithAutoReconnect: maxRetries upper bound (0 = unlimited)
-	maxSendBufFrames = 4096             // WithSendBufferSize upper bound
+	maxWriteTimeout    = 30 * time.Second // WithWriteTimeout upper bound
+	maxMsgSizeBytes    = 64 << 20         // WithMaxMessageSize upper bound — 64 MiB
+	maxBaseDelay       = 1 * time.Minute  // WithAutoReconnect: baseDelay upper bound
+	maxDelayLimit      = 5 * time.Minute  // WithAutoReconnect: maxDelay upper bound
+	maxRetriesLimit    = 32               // WithAutoReconnect: maxRetries upper bound (0 = unlimited)
+	maxSendBufMessages = 4096             // WithSendBufferSize upper bound
 )
 
 // ClientOption configures a Client.
 type ClientOption func(*clientConfig) //nolint:revive
 
 type clientConfig struct {
-	onMessage          func(wspulse.Frame)
+	onMessage          func(wspulse.Message)
 	onDisconnect       func(err error)
 	onTransportDrop    func(err error)
 	onTransportRestore func()
@@ -37,7 +37,7 @@ type clientConfig struct {
 	maxDelay           time.Duration
 	writeTimeout       time.Duration
 	maxMessageSize     int64 // max inbound message size in bytes; 0 = no size enforcement
-	sendBufferSize     int   // outbound channel capacity (number of frames)
+	sendBufferSize     int   // outbound channel capacity (number of messages)
 	clock              clock
 	dialer             dialer
 }
@@ -58,8 +58,8 @@ func defaultClientConfig() *clientConfig {
 	}
 }
 
-// WithOnMessage registers a callback invoked for every inbound Frame.
-func WithOnMessage(fn func(wspulse.Frame)) ClientOption {
+// WithOnMessage registers a callback invoked for every inbound Message.
+func WithOnMessage(fn func(wspulse.Message)) ClientOption {
 	return func(c *clientConfig) { c.onMessage = fn }
 }
 
@@ -139,7 +139,7 @@ func WithLogger(logger *zap.Logger) ClientOption {
 	return func(c *clientConfig) { c.logger = logger }
 }
 
-// WithWriteTimeout sets the timeout for write operations: data frames and the
+// WithWriteTimeout sets the timeout for write operations: data messages and the
 // close handshake. d must be in (0, 30s]. Default is 10s.
 func WithWriteTimeout(d time.Duration) ClientOption {
 	if d <= 0 {
@@ -151,14 +151,14 @@ func WithWriteTimeout(d time.Duration) ClientOption {
 	return func(c *clientConfig) { c.writeTimeout = d }
 }
 
-// WithSendBufferSize sets the outbound channel capacity (number of frames).
+// WithSendBufferSize sets the outbound channel capacity (number of messages).
 // n must be in [1, 4096]. Default is 256.
 func WithSendBufferSize(n int) ClientOption {
 	if n < 1 {
 		panic("wspulse: sendBufferSize must be at least 1")
 	}
-	if n > maxSendBufFrames {
-		panic(fmt.Sprintf("wspulse: sendBufferSize exceeds maximum (%d)", maxSendBufFrames))
+	if n > maxSendBufMessages {
+		panic(fmt.Sprintf("wspulse: sendBufferSize exceeds maximum (%d)", maxSendBufMessages))
 	}
 	return func(c *clientConfig) { c.sendBufferSize = n }
 }

--- a/reconnect_test.go
+++ b/reconnect_test.go
@@ -28,7 +28,7 @@ func TestAutoReconnect_ReconnectsAndDeliversMessages(t *testing.T) {
 	)
 
 	restored := make(chan struct{}, 5)
-	received := make(chan wspulse.Frame, 5)
+	received := make(chan wspulse.Message, 5)
 	c, err := client.Dial("ws://mock",
 		client.WithDialer(md),
 		client.WithClock(fc),
@@ -39,7 +39,7 @@ func TestAutoReconnect_ReconnectsAndDeliversMessages(t *testing.T) {
 			default:
 			}
 		}),
-		client.WithOnMessage(func(f wspulse.Frame) {
+		client.WithOnMessage(func(f wspulse.Message) {
 			select {
 			case received <- f:
 			default:
@@ -54,7 +54,7 @@ func TestAutoReconnect_ReconnectsAndDeliversMessages(t *testing.T) {
 	go echoLoop(mt1, echo1Done)
 
 	// Verify initial connectivity.
-	require.NoError(t, c.Send(wspulse.Frame{Event: "before", Payload: []byte(`"1"`)}), "Send before kick")
+	require.NoError(t, c.Send(wspulse.Message{Event: "before", Payload: []byte(`"1"`)}), "Send before kick")
 	f := requireReceive(t, received)
 	assert.Equal(t, "before", f.Event)
 
@@ -82,7 +82,7 @@ func TestAutoReconnect_ReconnectsAndDeliversMessages(t *testing.T) {
 	go echoLoop(mt2, echo2Done)
 
 	// Verify post-reconnect message delivery.
-	require.NoError(t, c.Send(wspulse.Frame{Event: "after", Payload: []byte(`"2"`)}), "Send after reconnect")
+	require.NoError(t, c.Send(wspulse.Message{Event: "after", Payload: []byte(`"2"`)}), "Send after reconnect")
 	f2 := requireReceive(t, received)
 	assert.Equal(t, "after", f2.Event)
 }
@@ -177,7 +177,7 @@ func TestAutoReconnect_MultipleRapidCycles(t *testing.T) {
 
 	var dropCount atomic.Int32
 	var restoreCount atomic.Int32
-	received := make(chan wspulse.Frame, 10)
+	received := make(chan wspulse.Message, 10)
 	restored := make(chan struct{}, cycles)
 
 	c, err := client.Dial("ws://mock",
@@ -194,7 +194,7 @@ func TestAutoReconnect_MultipleRapidCycles(t *testing.T) {
 			default:
 			}
 		}),
-		client.WithOnMessage(func(f wspulse.Frame) {
+		client.WithOnMessage(func(f wspulse.Message) {
 			select {
 			case received <- f:
 			default:
@@ -234,7 +234,7 @@ func TestAutoReconnect_MultipleRapidCycles(t *testing.T) {
 		go echoLoop(transports[idx], echoDone)
 	}
 
-	require.NoError(t, c.Send(wspulse.Frame{Event: "final", Payload: []byte(`"ok"`)}), "Send after cycles")
+	require.NoError(t, c.Send(wspulse.Message{Event: "final", Payload: []byte(`"ok"`)}), "Send after cycles")
 
 	f := requireReceive(t, received)
 	assert.Equal(t, "final", f.Event)
@@ -255,7 +255,7 @@ func TestAutoReconnect_Close_FiresOnDisconnect(t *testing.T) {
 			default:
 			}
 		}),
-		client.WithOnMessage(func(f wspulse.Frame) {
+		client.WithOnMessage(func(f wspulse.Message) {
 			select {
 			case received <- struct{}{}:
 			default:
@@ -268,8 +268,8 @@ func TestAutoReconnect_Close_FiresOnDisconnect(t *testing.T) {
 	defer close(echoDone)
 	go echoLoop(mt, echoDone)
 
-	// Confirm the connection is established by round-tripping a frame.
-	require.NoError(t, c.Send(wspulse.Frame{Event: "ping", Payload: []byte(`"1"`)}), "Send failed")
+	// Confirm the connection is established by round-tripping a message.
+	require.NoError(t, c.Send(wspulse.Message{Event: "ping", Payload: []byte(`"1"`)}), "Send failed")
 	requireReceive(t, received)
 
 	_ = c.Close()

--- a/testhelpers_test.go
+++ b/testhelpers_test.go
@@ -149,12 +149,12 @@ func requireDone(t *testing.T, c client.Client) {
 // failEncodeCodecComponent is a test codec whose Encode always returns an error.
 type failEncodeCodecComponent struct{}
 
-func (failEncodeCodecComponent) Encode(wspulse.Frame) ([]byte, error) {
+func (failEncodeCodecComponent) Encode(wspulse.Message) ([]byte, error) {
 	return nil, errors.New("wspulse: encode fail")
 }
 
-func (failEncodeCodecComponent) Decode(data []byte) (wspulse.Frame, error) {
-	return wspulse.Frame{}, nil
+func (failEncodeCodecComponent) Decode(data []byte) (wspulse.Message, error) {
+	return wspulse.Message{}, nil
 }
 
-func (failEncodeCodecComponent) FrameType() wspulse.MessageType { return wspulse.TextMessage }
+func (failEncodeCodecComponent) WireType() wspulse.MessageType { return wspulse.TextMessage }


### PR DESCRIPTION
## Summary

Rename `Frame` to `Message` and `FrameType()` to `WireType()` across the entire client-go module, aligning with the upstream core rename.

## Related issues

Closes #42
Relates to wspulse/.github#34

## Changes

- **`client.go`**: `Client.Send(f wspulse.Frame)` → `Client.Send(m wspulse.Message)`; `codec.FrameType()` → `codec.WireType()`; internal variable `frame` → `msg`; log message "frame dropped" → "message dropped"
- **`options.go`**: `func(wspulse.Frame)` → `func(wspulse.Message)` in `onMessage` field and `WithOnMessage`; GoDoc "inbound Frame" → "inbound Message"; `maxSendBufFrames` → `maxSendBufMessages`; "data frames" → "data messages"; "number of frames" → "number of messages"
- **`testhelpers_test.go`**: `failEncodeCodecComponent` methods updated: `Encode(wspulse.Frame)` → `Encode(wspulse.Message)`, `Decode` return type, `FrameType()` → `WireType()`
- **Test files** (`basic_test.go`, `callback_test.go`, `client_test.go`, `lifecycle_test.go`, `misc_test.go`, `reconnect_test.go`): all `wspulse.Frame` → `wspulse.Message`; variable names `frame` → `msg`, `wireFrame` → `wireMsg`, `validFrame` → `validMsg`; comments updated
- **`CHANGELOG.md`**: added `[Unreleased]` breaking change entries for Send, WithOnMessage, and WireType
- **`README.md`**: all code examples and prose updated; section "Frame Types" → "Message Types"; `c.Frame.Payload` → `c.Message.Payload`
- **`.github/copilot-instructions.md`**: `Frame` → `Message` in shared types list
- **`doc/component-tests.md`**: "Encoded frame" → "Encoded message"; "Malformed frame" → "Malformed message"

## Checklist

### Required

- [x] `make check` passes (`fmt` → `lint` → `test`)
- [x] Each commit represents exactly one logical change
- [x] Commit messages follow the format in `commit-message-instructions.md`
- [x] No unrelated code reformatting in this PR

### Conditional (list only those that apply)

- [x] Breaking change: major version bump discussed in linked issue