### PR TITLE
feat: preserve server close frame code and reason in ServerClosedError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- **BREAKING**: `ErrServerClosed` sentinel replaced by `ServerClosedError` struct carrying `Code wspulse.StatusCode` and `Reason string`. `coderTransport.Read` now extracts the exact close code and reason from the server's close frame. Use `errors.As(err, &sce)` to inspect the values; `errors.Is(err, &ServerClosedError{})` works as a type-check shortcut. See [wspulse/.github#37](https://github.com/wspulse/.github/issues/37).
+
 ## [0.9.0] - 2026-04-20
 
 ### Changed

--- a/client.go
+++ b/client.go
@@ -22,10 +22,40 @@ var ErrRetriesExhausted = errors.New("wspulse: max reconnect retries exhausted")
 // connection and auto-reconnect is disabled.
 var ErrConnectionLost = errors.New("wspulse: connection lost")
 
-// ErrServerClosed is returned to OnTransportDrop when the server initiated a
-// WebSocket close handshake by sending a close frame. This is a protocol-level
+// ServerClosedError is returned to OnTransportDrop when the server initiated
+// a WebSocket close handshake by sending a close frame. It carries the close
+// status code and reason string sent by the server. This is a protocol-level
 // intentional close, distinct from an abrupt network drop.
-var ErrServerClosed = errors.New("wspulse: server closed connection")
+//
+// Callers extract the code and reason via errors.As:
+//
+//	var sce *client.ServerClosedError
+//	if errors.As(err, &sce) {
+//	    log.Printf("server closed: code=%d reason=%q", sce.Code, sce.Reason)
+//	}
+//
+// errors.Is(err, &client.ServerClosedError{}) matches any *ServerClosedError
+// regardless of code or reason, providing a type-check shortcut similar to
+// a sentinel error.
+type ServerClosedError struct {
+	Code   wspulse.StatusCode
+	Reason string
+}
+
+// Error implements the error interface.
+func (e *ServerClosedError) Error() string {
+	if e.Reason == "" {
+		return fmt.Sprintf("wspulse: server closed connection: code=%d", e.Code)
+	}
+	return fmt.Sprintf("wspulse: server closed connection: code=%d, reason=%q", e.Code, e.Reason)
+}
+
+// Is reports whether target is any *ServerClosedError, enabling
+// errors.Is(err, &ServerClosedError{}) as a type-check shortcut.
+func (e *ServerClosedError) Is(target error) bool {
+	_, ok := target.(*ServerClosedError)
+	return ok
+}
 
 // Client is the public interface for the WebSocket client.
 type Client interface {
@@ -248,7 +278,7 @@ func (c *internalClient) readPump(ctx context.Context, trans transport, dropped 
 		// Determine the root-cause error for onTransportDrop:
 		//   1. User-initiated close → nil (behaviour contract).
 		//   2. writePump reported an error → use it (root cause).
-		//   3. Otherwise → readPump's own readErr (may be ErrServerClosed from adapter).
+		//   3. Otherwise → readPump's own readErr (may be *ServerClosedError from adapter).
 		select {
 		case <-c.done:
 			readErr = nil

--- a/server_closed_error_test.go
+++ b/server_closed_error_test.go
@@ -1,0 +1,48 @@
+package client_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/wspulse/client-go"
+	wspulse "github.com/wspulse/core"
+)
+
+func TestServerClosedError_Error(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name string
+		err  *client.ServerClosedError
+		want string
+	}{
+		{
+			name: "with reason",
+			err:  &client.ServerClosedError{Code: wspulse.StatusGoingAway, Reason: "server shutting down"},
+			want: `wspulse: server closed connection: code=1001, reason="server shutting down"`,
+		},
+		{
+			name: "empty reason",
+			err:  &client.ServerClosedError{Code: wspulse.StatusNormalClosure, Reason: ""},
+			want: "wspulse: server closed connection: code=1000",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.want, tc.err.Error())
+		})
+	}
+}
+
+func TestServerClosedError_Is_MatchesAnyServerClosedError(t *testing.T) {
+	t.Parallel()
+	// Is() enables errors.Is(err, &ServerClosedError{}) as a type-check
+	// shortcut — matches any *ServerClosedError regardless of code or reason.
+	err := &client.ServerClosedError{Code: wspulse.StatusPolicyViolation, Reason: "kicked"}
+
+	assert.True(t, errors.Is(err, &client.ServerClosedError{}),
+		"errors.Is should match any *ServerClosedError")
+	assert.False(t, errors.Is(err, errors.New("other")),
+		"errors.Is should not match an unrelated error")
+}

--- a/transport.go
+++ b/transport.go
@@ -37,9 +37,11 @@ var _ transport = (*coderTransport)(nil)
 func (t *coderTransport) Read(ctx context.Context) (wspulse.MessageType, []byte, error) {
 	typ, data, err := t.conn.Read(ctx)
 	if err != nil {
-		// Server sent a WebSocket close frame. Extract the exact code and
-		// reason into *ServerClosedError so callers can inspect them via
-		// errors.As without importing coder/websocket.
+		// If the read failed due to a server WebSocket close frame, extract
+		// the exact code and reason into *ServerClosedError so callers can
+		// inspect them via errors.As without importing coder/websocket.
+		// Non-close errors (timeouts, context cancellation, I/O) pass through
+		// unchanged.
 		var ce websocket.CloseError
 		if errors.As(err, &ce) {
 			err = &ServerClosedError{

--- a/transport.go
+++ b/transport.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"context"
+	"errors"
 
 	"github.com/coder/websocket"
 
@@ -35,10 +36,17 @@ var _ transport = (*coderTransport)(nil)
 
 func (t *coderTransport) Read(ctx context.Context) (wspulse.MessageType, []byte, error) {
 	typ, data, err := t.conn.Read(ctx)
-	if err != nil && websocket.CloseStatus(err) != -1 {
-		// Server sent a WebSocket close frame. Return ErrServerClosed directly
-		// so callers can use errors.Is without importing coder/websocket.
-		err = ErrServerClosed
+	if err != nil {
+		// Server sent a WebSocket close frame. Extract the exact code and
+		// reason into *ServerClosedError so callers can inspect them via
+		// errors.As without importing coder/websocket.
+		var ce websocket.CloseError
+		if errors.As(err, &ce) {
+			err = &ServerClosedError{
+				Code:   wspulse.StatusCode(ce.Code),
+				Reason: ce.Reason,
+			}
+		}
 	}
 	return wspulse.MessageType(typ), data, err
 }

--- a/transport_adapter_test.go
+++ b/transport_adapter_test.go
@@ -11,20 +11,24 @@ import (
 	"github.com/coder/websocket"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	wspulse "github.com/wspulse/core"
 )
 
-// TestCoderTransport_Read_WrapsCloseFrameAsErrServerClosed verifies that
-// coderTransport.Read wraps any WebSocket close frame into ErrServerClosed.
-// This ensures callers do not need to import coder/websocket to classify the
-// error — errors.Is(err, ErrServerClosed) is sufficient.
-func TestCoderTransport_Read_WrapsCloseFrameAsErrServerClosed(t *testing.T) {
+// TestCoderTransport_Read_WrapsCloseFrameAsServerClosedError verifies that
+// coderTransport.Read wraps any WebSocket close frame into *ServerClosedError
+// carrying the exact code and reason sent by the server. Callers extract
+// them via errors.As without importing coder/websocket.
+func TestCoderTransport_Read_WrapsCloseFrameAsServerClosedError(t *testing.T) {
 	for _, tc := range []struct {
-		name string
-		code websocket.StatusCode
+		name       string
+		code       websocket.StatusCode
+		reason     string
+		wantStatus wspulse.StatusCode
 	}{
-		{"normal closure (1000)", websocket.StatusNormalClosure},
-		{"policy violation (1008)", websocket.StatusPolicyViolation},
-		{"going away (1001)", websocket.StatusGoingAway},
+		{"normal closure (1000)", websocket.StatusNormalClosure, "bye", wspulse.StatusNormalClosure},
+		{"policy violation (1008)", websocket.StatusPolicyViolation, "nope", wspulse.StatusPolicyViolation},
+		{"going away (1001)", websocket.StatusGoingAway, "server shutting down", wspulse.StatusGoingAway},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
@@ -35,7 +39,7 @@ func TestCoderTransport_Read_WrapsCloseFrameAsErrServerClosed(t *testing.T) {
 					t.Errorf("websocket.Accept: %v", err)
 					return
 				}
-				_ = conn.Close(tc.code, "test close")
+				_ = conn.Close(tc.code, tc.reason)
 			}))
 			t.Cleanup(srv.Close)
 
@@ -51,8 +55,11 @@ func TestCoderTransport_Read_WrapsCloseFrameAsErrServerClosed(t *testing.T) {
 			_, _, readErr := transport.Read(ctx)
 
 			require.Error(t, readErr)
-			assert.ErrorIs(t, readErr, ErrServerClosed,
-				"want ErrServerClosed for close code %d, got: %v", tc.code, readErr)
+			var sce *ServerClosedError
+			require.ErrorAs(t, readErr, &sce,
+				"want *ServerClosedError for close code %d, got: %v", tc.code, readErr)
+			assert.Equal(t, tc.wantStatus, sce.Code, "close code mismatch")
+			assert.Equal(t, tc.reason, sce.Reason, "close reason mismatch")
 		})
 	}
 }

--- a/transport_drop_test.go
+++ b/transport_drop_test.go
@@ -4,26 +4,37 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/wspulse/client-go"
+	wspulse "github.com/wspulse/core"
 )
 
-// B1 — ErrServerClosed: server close frame path (component — mock transport)
+// B1 — ServerClosedError: server close frame path (component — mock transport)
 
-func TestOnTransportDrop_ServerClosedFrame_IsErrServerClosed(t *testing.T) {
+func TestOnTransportDrop_ServerClosedFrame_IsServerClosedError(t *testing.T) {
 	t.Parallel()
-	// The transport adapter returns ErrServerClosed directly when the server
-	// sends a close frame. Inject it via mock to verify the
-	// readPump → onTransportDrop propagation path.
+	// The transport adapter returns *ServerClosedError directly when the
+	// server sends a close frame. Inject it via mock to verify the
+	// readPump → onTransportDrop propagation preserves Code and Reason.
 	dropErr := make(chan error, 1)
 	c, mt, _ := dialWithMock(t,
 		client.WithOnTransportDrop(func(e error) { dropErr <- e }),
 	)
 	t.Cleanup(func() { _ = c.Close() })
 
-	mt.InjectError(client.ErrServerClosed)
+	injected := &client.ServerClosedError{
+		Code:   wspulse.StatusGoingAway,
+		Reason: "server shutting down",
+	}
+	mt.InjectError(injected)
 
 	got := requireReceive(t, dropErr)
-	assert.ErrorIs(t, got, client.ErrServerClosed,
-		"want ErrServerClosed on server close frame, got: %v", got)
+	var sce *client.ServerClosedError
+	require.ErrorAs(t, got, &sce,
+		"want *ServerClosedError on server close frame, got: %v", got)
+	assert.Equal(t, wspulse.StatusGoingAway, sce.Code)
+	assert.Equal(t, "server shutting down", sce.Reason)
+	assert.ErrorIs(t, got, &client.ServerClosedError{},
+		"errors.Is should match any *ServerClosedError as a type-check shortcut")
 }


### PR DESCRIPTION
## Summary

Preserve the WebSocket close frame code and reason through the transport layer so `onTransportDrop` callers can distinguish server-initiated disconnect causes (e.g. going away vs policy violation) instead of seeing a generic sentinel error.

## Related issues

Relates to wspulse/.github#37

## Changes

- Replace the `ErrServerClosed` sentinel with a `ServerClosedError{Code, Reason}` struct. `errors.Is(err, &ServerClosedError{})` continues to match any instance via a custom `Is()` method.
- `coderTransport.Read()` extracts `Code` and `Reason` from `websocket.CloseError` via `errors.As` and wraps them in `*ServerClosedError`.
- Update `transport_adapter_test.go` and `transport_drop_test.go` to assert on `Code`/`Reason` for 1000/1001/1008 close frames.
- Add `server_closed_error_test.go` covering `Error()` formatting (with and without reason) and `Is()` semantics.
- CHANGELOG: breaking API change — sentinel replaced by struct with fields.

## Checklist

### Required

- [x] `make check` passes (`fmt` → `lint` → `test`)
- [x] Each commit represents exactly one logical change
- [x] Commit messages follow the format in `commit-message-instructions.md`
- [x] No unrelated code reformatting in this PR

### Conditional

- [x] Breaking change: v0, no compatibility guarantee; tracked in linked issue
- [x] New public API: includes GoDoc comments
