### PR TITLE
chore: bench-sync mktemp + b.Loop migration follow-ups

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ bench-ci: ## Run the CI benchmark suite and write results to BENCH_OUT or bench.
 bench-sync: ## Refresh doc/bench.md from a fresh local benchmark run
 	@echo "── running benchmarks ──"
 	@set -e; \
-		tmpfile="$$(mktemp)"; \
+		tmpfile="$$(mktemp -t wspulse-benchsync.XXXXXX)"; \
 		trap 'rm -f "$$tmpfile"' EXIT; \
 		$(MAKE) --no-print-directory bench-ci BENCH_OUT="$$tmpfile"; \
 		echo "── refreshing doc/bench.md ──"; \

--- a/client_bench_test.go
+++ b/client_bench_test.go
@@ -109,8 +109,8 @@ func BenchmarkSend(b *testing.B) {
 	}
 }
 
-// benchSend measures b.N batches of `loop` Send calls each. Reported ns/op is
-// per-batch cost; divide by `loop` to get per-message cost.
+// benchSend measures `loop` Send calls per timed iteration. Reported ns/op
+// is per-batch cost; divide by `loop` to get per-message cost.
 func benchSend(b *testing.B, loop, payloadSize int) {
 	ts := startWSSink(b)
 
@@ -129,8 +129,7 @@ func benchSend(b *testing.B, loop, payloadSize int) {
 	// Direct sentinel comparison (not errors.Is) keeps the hot path cheap.
 	var unexpectedErrs int
 	b.ReportAllocs()
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		for j := 0; j < loop; j++ {
 			// ErrSendBufferFull is expected at benchmark speed when writePump
 			// cannot keep up with enqueue rate. The bench measures Send call
@@ -140,7 +139,8 @@ func benchSend(b *testing.B, loop, payloadSize int) {
 			}
 		}
 	}
-	b.StopTimer()
+	// The check runs outside the timed region — b.Loop has already returned
+	// false and the timer is stopped before we read unexpectedErrs.
 	if unexpectedErrs > 0 {
 		b.Fatalf("got %d unexpected Send errors during bench", unexpectedErrs)
 	}
@@ -158,8 +158,9 @@ func BenchmarkReconnectBackoff(b *testing.B) {
 		max  = 30 * time.Second
 	)
 	b.ReportAllocs()
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	i := 0
+	for b.Loop() {
 		_ = backoff(i%30, base, max)
+		i++
 	}
 }

--- a/doc/bench.md
+++ b/doc/bench.md
@@ -26,14 +26,14 @@ Measured on `darwin/arm64` (`Apple M1 Max`).
 
 | Operation | ns/op | B/op | allocs/op |
 |---|---:|---:|---:|
-| `Send (single, 64 B)` | 525.1 | 340 | 4 |
-| `Send (single, 1 KiB)` | 4,868 | 5,113 | 40 |
-| `Send (single, 16 KiB)` | 68,742 | 61,580 | 92 |
-| `Send (loop_10, 64 B)` | 5,251 | 3,480 | 48 |
-| `Send (loop_10, 1 KiB)` | 48,826 | 51,488 | 408 |
-| `Send (loop_10, 16 KiB)` | 686,637 | 615,660 | 921 |
-| `Send (loop_100, 64 B)` | 52,651 | 34,722 | 480 |
-| `Send (loop_100, 1 KiB)` | 488,082 | 513,267 | 4,068 |
-| `Send (loop_100, 16 KiB)` | 6,893,634 | 6,157,370 | 9,211 |
-| `Reconnect backoff` | 7.207 | 0 | 0 |
+| `Send (single, 64 B)` | 577.3 | 354 | 4 |
+| `Send (single, 1 KiB)` | 4,868 | 4,975 | 39 |
+| `Send (single, 16 KiB)` | 69,404 | 61,566 | 92 |
+| `Send (loop_10, 64 B)` | 5,402 | 3,300 | 45 |
+| `Send (loop_10, 1 KiB)` | 48,818 | 50,027 | 394 |
+| `Send (loop_10, 16 KiB)` | 696,082 | 615,715 | 921 |
+| `Send (loop_100, 64 B)` | 54,600 | 33,420 | 462 |
+| `Send (loop_100, 1 KiB)` | 494,087 | 507,640 | 4,013 |
+| `Send (loop_100, 16 KiB)` | 6,918,477 | 6,157,130 | 9,211 |
+| `Reconnect backoff` | 7.824 | 0 | 0 |
 <!-- benchsync:client-go:end -->


### PR DESCRIPTION
## Summary

Follow-up cleanup to #61 (bench harness). Three small consistency fixes
caught while reviewing parallel core / hub PRs:

1. `mktemp` without a template fails on some BSD-flavoured `mktemp` —
   switched to `mktemp -t wspulse-benchsync.XXXXXX`.
2. New benches still used `for i := 0; i < b.N; i++` while the rest of
   the workspace (and `core` / `hub` v1 baselines) standardised on
   `b.Loop()`. Migrated `BenchmarkSend` and `BenchmarkReconnectBackoff`.
3. Refreshed `doc/bench.md` so the checked-in baseline reflects the
   `b.Loop()` numbers.

No behavioural change; all benches still measure the same operations.

## Related issues

(none — pure consistency follow-up)

## Changes

- `Makefile`: `mktemp` → `mktemp -t wspulse-benchsync.XXXXXX`.
- `client_bench_test.go`: `for i := 0; i < b.N; i++` → `for b.Loop()`.
  Removed redundant `b.ResetTimer` / `b.StopTimer` (b.Loop handles both).
- `doc/bench.md`: regenerated baseline numbers.

## Checklist

### Required

- [x] `make check` passes (`fmt` → `lint` → `test`)
- [x] Each commit represents exactly one logical change
- [x] Commit messages follow the format in `commit-message-instructions.md`
- [x] No unrelated code reformatting in this PR
