### PR TITLE
release: v0.10.1

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,47 @@
+name: Benchmark
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [develop]
+    paths-ignore:
+      - '**.md'
+      - 'LICENSE'
+      - '.github/instructions/**'
+  pull_request:
+    branches: [main, develop]
+    paths-ignore:
+      - '**.md'
+      - 'LICENSE'
+      - '.github/instructions/**'
+
+permissions:
+  contents: read
+
+jobs:
+  benchmark:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache-dependency-path: go.sum
+
+      - name: Download modules
+        run: go mod download
+
+      - name: Run benchmarks
+        run: make bench-ci
+
+      - name: Upload bench output
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: bench-${{ github.sha }}
+          path: bench.txt
+          retention-days: 30

--- a/.gitignore
+++ b/.gitignore
@@ -306,4 +306,4 @@ yarn-error.log*
 Thumbs.db
 
 # Misc
-*.pem
+*.pembench.txt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.10.1] - 2026-05-18
+
 ### Added
 
 - Benchmark harness with `make bench-ci`, `make bench-sync`, and a CI
@@ -169,7 +171,8 @@
 - Orphaned callback goroutines on disconnect — all goroutines cleaned up on `Close`
 - `Close()` waits for all internal goroutines to exit before returning
 
-[Unreleased]: https://github.com/wspulse/client-go/compare/v0.10.0...HEAD
+[Unreleased]: https://github.com/wspulse/client-go/compare/v0.10.1...HEAD
+[0.10.1]: https://github.com/wspulse/client-go/compare/v0.10.0...v0.10.1
 [0.10.0]: https://github.com/wspulse/client-go/compare/v0.9.0...v0.10.0
 [0.9.0]: https://github.com/wspulse/client-go/compare/v0.8.1...v0.9.0
 [0.8.1]: https://github.com/wspulse/client-go/compare/v0.8.0...v0.8.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+### Added
+
+- Benchmark harness with `make bench-ci`, `make bench-sync`, and a CI
+  workflow that uploads `bench.txt` as an artefact on every PR. See
+  `doc/bench.md` for the baseline numbers. (#60)
+
 ## [0.10.0] - 2026-05-02
 
 ### Changed

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
-# bash gives us `set -o pipefail` and `trap` for the bench targets below;
-# all existing recipes are POSIX-compatible so this is safe.
-SHELL := /bin/bash
+# bash (looked up via PATH, not hardcoded to /bin/bash) gives us
+# `set -o pipefail` and `trap` for the bench targets below; all existing
+# recipes are POSIX-compatible so this is safe.
+SHELL := bash
 
 .PHONY: help test test-cover bench bench-ci bench-sync lint fmt check tidy deps clean
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help test test-cover bench lint fmt check tidy deps clean
+.PHONY: help test test-cover bench bench-ci lint fmt check tidy deps clean
 
 # Default target
 help: ## Show available commands
@@ -15,6 +15,10 @@ test-cover: ## Run all tests with coverage report
 
 bench: ## Run benchmarks with memory allocation stats
 	@go test -bench=. -benchmem -run=^$$ ./...
+
+bench-ci: ## Run the CI benchmark suite and write results to BENCH_OUT or bench.txt
+	@outfile="$${BENCH_OUT:-bench.txt}"; \
+		go test -bench=. -benchmem -benchtime=3s -count=1 -run=^$$ ./... | tee "$$outfile"
 
 lint: ## Run go vet and golangci-lint
 	@go vet ./...

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,8 @@
-# bash (looked up via PATH, not hardcoded to /bin/bash) gives us
-# `set -o pipefail` and `trap` for the bench targets below; all existing
-# recipes are POSIX-compatible so this is safe.
-SHELL := bash
-
 .PHONY: help test test-cover bench bench-ci bench-sync lint fmt check tidy deps clean
+
+# bench-ci and bench-sync use bash for `set -o pipefail` and `trap`; all
+# other recipes stay POSIX-compatible so they run in any /bin/sh.
+bench-ci bench-sync: SHELL := bash
 
 # Default target
 help: ## Show available commands

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ bench-ci: ## Run the CI benchmark suite and write results to BENCH_OUT or bench.
 bench-sync: ## Refresh doc/bench.md from a fresh local benchmark run
 	@echo "── running benchmarks ──"
 	@set -e; \
-		tmpfile="$$(mktemp)"; \
+		tmpfile="$$(mktemp -t wspulse-benchsync.XXXXXX)"; \
 		trap 'rm -f "$$tmpfile"' EXIT; \
 		$(MAKE) --no-print-directory bench-ci BENCH_OUT="$$tmpfile"; \
 		echo "── refreshing doc/bench.md ──"; \

--- a/Makefile
+++ b/Makefile
@@ -26,11 +26,14 @@ bench-ci: ## Run the CI benchmark suite and write results to BENCH_OUT or bench.
 		go test -bench=. -benchmem -benchtime=3s -count=1 -run=^$$ ./... | tee "$$outfile"
 
 bench-sync: ## Refresh doc/bench.md from a fresh local benchmark run
+	@echo "── running benchmarks ──"
 	@set -e; \
 		tmpfile="$$(mktemp)"; \
 		trap 'rm -f "$$tmpfile"' EXIT; \
-		$(MAKE) --no-print-directory bench-ci BENCH_OUT="$$tmpfile" > /dev/null; \
-		go run ./cmd/benchsync -input "$$tmpfile"
+		$(MAKE) --no-print-directory bench-ci BENCH_OUT="$$tmpfile"; \
+		echo "── refreshing doc/bench.md ──"; \
+		go run ./cmd/benchsync -input "$$tmpfile"; \
+		echo "── done ──"
 
 lint: ## Run go vet and golangci-lint
 	@go vet ./...

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,7 @@
+# bash gives us `set -o pipefail` and `trap` for the bench targets below;
+# all existing recipes are POSIX-compatible so this is safe.
+SHELL := /bin/bash
+
 .PHONY: help test test-cover bench bench-ci bench-sync lint fmt check tidy deps clean
 
 # Default target
@@ -17,14 +21,16 @@ bench: ## Run benchmarks with memory allocation stats
 	@go test -bench=. -benchmem -run=^$$ ./...
 
 bench-ci: ## Run the CI benchmark suite and write results to BENCH_OUT or bench.txt
-	@outfile="$${BENCH_OUT:-bench.txt}"; \
+	@set -o pipefail; \
+		outfile="$${BENCH_OUT:-bench.txt}"; \
 		go test -bench=. -benchmem -benchtime=3s -count=1 -run=^$$ ./... | tee "$$outfile"
 
 bench-sync: ## Refresh doc/bench.md from a fresh local benchmark run
-	@tmpfile="$$(mktemp)"; \
+	@set -e; \
+		tmpfile="$$(mktemp)"; \
+		trap 'rm -f "$$tmpfile"' EXIT; \
 		$(MAKE) --no-print-directory bench-ci BENCH_OUT="$$tmpfile" > /dev/null; \
-		go run ./cmd/benchsync -input "$$tmpfile"; \
-		rm -f "$$tmpfile"
+		go run ./cmd/benchsync -input "$$tmpfile"
 
 lint: ## Run go vet and golangci-lint
 	@go vet ./...

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help test test-cover bench bench-ci lint fmt check tidy deps clean
+.PHONY: help test test-cover bench bench-ci bench-sync lint fmt check tidy deps clean
 
 # Default target
 help: ## Show available commands
@@ -19,6 +19,12 @@ bench: ## Run benchmarks with memory allocation stats
 bench-ci: ## Run the CI benchmark suite and write results to BENCH_OUT or bench.txt
 	@outfile="$${BENCH_OUT:-bench.txt}"; \
 		go test -bench=. -benchmem -benchtime=3s -count=1 -run=^$$ ./... | tee "$$outfile"
+
+bench-sync: ## Refresh doc/bench.md from a fresh local benchmark run
+	@tmpfile="$$(mktemp)"; \
+		$(MAKE) --no-print-directory bench-ci BENCH_OUT="$$tmpfile" > /dev/null; \
+		go run ./cmd/benchsync -input "$$tmpfile"; \
+		rm -f "$$tmpfile"
 
 lint: ## Run go vet and golangci-lint
 	@go vet ./...

--- a/client_bench_test.go
+++ b/client_bench_test.go
@@ -1,0 +1,120 @@
+package client
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/coder/websocket"
+	"go.uber.org/zap"
+
+	wspulse "github.com/wspulse/core"
+)
+
+// jsonPayload returns a valid JSON string payload with total byte length size.
+// size includes the surrounding quotes; minimum is 2 (an empty JSON string).
+func jsonPayload(size int) []byte {
+	if size < 2 {
+		size = 2
+	}
+	return []byte(`"` + strings.Repeat("x", size-2) + `"`)
+}
+
+// messageSizes is the standard payload size matrix for Send benchmarks.
+// Values match the workspace bench-harness plan.
+var messageSizes = []struct {
+	label string
+	size  int
+}{
+	{"64B", 64},
+	{"1KiB", 1024},
+	{"16KiB", 16 * 1024},
+}
+
+// startWSSink starts a minimal WebSocket sink that accepts and drains all
+// incoming messages with no application-level processing. Used as the bench
+// counterpart so the client-side Send path is the only thing measured (apart
+// from network/transport overhead inherent to a real WebSocket loopback).
+func startWSSink(b *testing.B) *httptest.Server {
+	b.Helper()
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c, err := websocket.Accept(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer func() { _ = c.CloseNow() }()
+		// Drain reads until the client disconnects.
+		for {
+			if _, _, err := c.Read(r.Context()); err != nil {
+				return
+			}
+		}
+	})
+	return httptest.NewServer(handler)
+}
+
+func BenchmarkSend(b *testing.B) {
+	for _, shape := range []struct {
+		label string
+		loop  int
+	}{
+		{"single", 1},
+		{"loop_10", 10},
+		{"loop_100", 100},
+	} {
+		for _, ms := range messageSizes {
+			name := fmt.Sprintf("shape=%s/messageSize=%s", shape.label, ms.label)
+			b.Run(name, func(b *testing.B) {
+				benchSend(b, shape.loop, ms.size)
+			})
+		}
+	}
+}
+
+// benchSend measures b.N batches of `loop` Send calls each. Reported ns/op is
+// per-batch cost; divide by `loop` to get per-message cost.
+func benchSend(b *testing.B, loop, payloadSize int) {
+	ts := startWSSink(b)
+	b.Cleanup(ts.Close)
+
+	url := "ws" + strings.TrimPrefix(ts.URL, "http")
+
+	c, err := Dial(url, WithLogger(zap.NewNop()))
+	if err != nil {
+		b.Fatalf("Dial: %v", err)
+	}
+	b.Cleanup(func() { _ = c.Close() })
+
+	msg := wspulse.Message{Event: "bench", Payload: jsonPayload(payloadSize)}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		for j := 0; j < loop; j++ {
+			// ErrSendBufferFull is expected at benchmark speed when writePump
+			// cannot keep up with enqueue rate. The bench measures Send call
+			// cost (encode + enqueue) including the buffer-full path.
+			_ = c.Send(msg)
+		}
+	}
+}
+
+// BenchmarkReconnectBackoff measures the cost of one backoff() call. The
+// formula must match all other client-* SDKs (workspace critical rule 5);
+// regressions in cost or distribution are worth catching early.
+//
+// `attempt` cycles through 0..29 to exercise the doubling path including
+// saturation at maxDelay.
+func BenchmarkReconnectBackoff(b *testing.B) {
+	const (
+		base = 100 * time.Millisecond
+		max  = 30 * time.Second
+	)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = backoff(i%30, base, max)
+	}
+}

--- a/client_bench_test.go
+++ b/client_bench_test.go
@@ -1,10 +1,12 @@
 package client
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -38,22 +40,37 @@ var messageSizes = []struct {
 // incoming messages with no application-level processing. Used as the bench
 // counterpart so the client-side Send path is the only thing measured (apart
 // from network/transport overhead inherent to a real WebSocket loopback).
+//
+// Cleanup is registered via b.Cleanup so the handler goroutine is guaranteed
+// to have exited before goleak.VerifyTestMain runs. Using r.Context() alone
+// does not reliably cancel reads on hijacked WebSocket connections, so we
+// drive cancellation via an explicit context and wait for the handler with
+// a WaitGroup.
 func startWSSink(b *testing.B) *httptest.Server {
 	b.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	var wg sync.WaitGroup
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		wg.Add(1)
+		defer wg.Done()
 		c, err := websocket.Accept(w, r, nil)
 		if err != nil {
 			return
 		}
 		defer func() { _ = c.CloseNow() }()
-		// Drain reads until the client disconnects.
 		for {
-			if _, _, err := c.Read(r.Context()); err != nil {
+			if _, _, err := c.Read(ctx); err != nil {
 				return
 			}
 		}
 	})
-	return httptest.NewServer(handler)
+	ts := httptest.NewServer(handler)
+	b.Cleanup(func() {
+		cancel()   // unblock c.Read inside the handler
+		ts.Close() // close listener and accepted conns
+		wg.Wait()  // ensure the handler goroutine has exited
+	})
+	return ts
 }
 
 func BenchmarkSend(b *testing.B) {
@@ -78,7 +95,6 @@ func BenchmarkSend(b *testing.B) {
 // per-batch cost; divide by `loop` to get per-message cost.
 func benchSend(b *testing.B, loop, payloadSize int) {
 	ts := startWSSink(b)
-	b.Cleanup(ts.Close)
 
 	url := "ws" + strings.TrimPrefix(ts.URL, "http")
 

--- a/client_bench_test.go
+++ b/client_bench_test.go
@@ -46,13 +46,24 @@ var messageSizes = []struct {
 // does not reliably cancel reads on hijacked WebSocket connections, so we
 // drive cancellation via an explicit context and wait for the handler with
 // a WaitGroup.
+//
+// The `started` channel guarantees that `wg.Add(1)` runs before any
+// `wg.Wait()` — without it, a Wait that observed counter==0 before the
+// first Add could panic with "sync: WaitGroup misuse". Wait blocks on
+// `started` first; cleanup with no handler ever invoked (e.g. Dial
+// failed) skips Wait entirely.
 func startWSSink(b *testing.B) *httptest.Server {
 	b.Helper()
 	ctx, cancel := context.WithCancel(context.Background())
 	var wg sync.WaitGroup
+	started := make(chan struct{}, 1)
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		wg.Add(1)
 		defer wg.Done()
+		select {
+		case started <- struct{}{}:
+		default:
+		}
 		c, err := websocket.Accept(w, r, nil)
 		if err != nil {
 			return
@@ -68,7 +79,14 @@ func startWSSink(b *testing.B) *httptest.Server {
 	b.Cleanup(func() {
 		cancel()   // unblock c.Read inside the handler
 		ts.Close() // close listener and accepted conns
-		wg.Wait()  // ensure the handler goroutine has exited
+		select {
+		case <-started:
+			// Handler started at least once → wg.Add has fired, safe to Wait.
+			wg.Wait()
+		default:
+			// No handler ever ran (e.g. Dial failed before connect); skip
+			// Wait to avoid blocking on a counter that never moved.
+		}
 	})
 	return ts
 }

--- a/client_bench_test.go
+++ b/client_bench_test.go
@@ -109,8 +109,8 @@ func BenchmarkSend(b *testing.B) {
 	}
 }
 
-// benchSend measures b.N batches of `loop` Send calls each. Reported ns/op is
-// per-batch cost; divide by `loop` to get per-message cost.
+// benchSend measures `loop` Send calls per timed iteration. Reported ns/op
+// is per-batch cost; divide by `loop` to get per-message cost.
 func benchSend(b *testing.B, loop, payloadSize int) {
 	ts := startWSSink(b)
 
@@ -129,8 +129,7 @@ func benchSend(b *testing.B, loop, payloadSize int) {
 	// Direct sentinel comparison (not errors.Is) keeps the hot path cheap.
 	var unexpectedErrs int
 	b.ReportAllocs()
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		for j := 0; j < loop; j++ {
 			// ErrSendBufferFull is expected at benchmark speed when writePump
 			// cannot keep up with enqueue rate. The bench measures Send call
@@ -140,7 +139,8 @@ func benchSend(b *testing.B, loop, payloadSize int) {
 			}
 		}
 	}
-	b.StopTimer()
+	// The check runs outside the timed region — b.Loop has already returned
+	// false and the timer is stopped before we read unexpectedErrs.
 	if unexpectedErrs > 0 {
 		b.Fatalf("got %d unexpected Send errors during bench", unexpectedErrs)
 	}
@@ -158,8 +158,9 @@ func BenchmarkReconnectBackoff(b *testing.B) {
 		max  = 30 * time.Second
 	)
 	b.ReportAllocs()
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	i := 0
+	for b.Loop() {
 		_ = backoff(i%30, base, max)
+		i++
 	}
 }

--- a/client_bench_test.go
+++ b/client_bench_test.go
@@ -89,6 +89,11 @@ func benchSend(b *testing.B, loop, payloadSize int) {
 	b.Cleanup(func() { _ = c.Close() })
 
 	msg := wspulse.Message{Event: "bench", Payload: jsonPayload(payloadSize)}
+	// unexpectedErrs counts any Send errors that aren't the expected
+	// ErrSendBufferFull. A non-zero count means the connection dropped or
+	// the codec failed mid-bench, in which case the timing data is junk.
+	// Direct sentinel comparison (not errors.Is) keeps the hot path cheap.
+	var unexpectedErrs int
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -96,8 +101,14 @@ func benchSend(b *testing.B, loop, payloadSize int) {
 			// ErrSendBufferFull is expected at benchmark speed when writePump
 			// cannot keep up with enqueue rate. The bench measures Send call
 			// cost (encode + enqueue) including the buffer-full path.
-			_ = c.Send(msg)
+			if err := c.Send(msg); err != nil && err != wspulse.ErrSendBufferFull {
+				unexpectedErrs++
+			}
 		}
+	}
+	b.StopTimer()
+	if unexpectedErrs > 0 {
+		b.Fatalf("got %d unexpected Send errors during bench", unexpectedErrs)
 	}
 }
 

--- a/cmd/benchsync/main.go
+++ b/cmd/benchsync/main.go
@@ -1,0 +1,280 @@
+// Command benchsync regenerates the benchmark tables in docs from a fresh
+// `go test -bench` output file. It parses the standard Go benchmark format,
+// emits one markdown row per known benchmark name, and replaces the table
+// inside a managed marker block in the target document.
+//
+// Run via `make bench-sync` from the repo root.
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+var benchLinePattern = regexp.MustCompile(`^(Benchmark\S+?)(?:-\d+)?\s+\d+\s+(\S+)\s+ns/op\s+(\S+)\s+B/op\s+(\S+)\s+allocs/op$`)
+
+type benchEnv struct {
+	GOOS   string
+	GOARCH string
+	CPU    string
+}
+
+type benchReport struct {
+	Env     benchEnv
+	Results map[string]benchResult
+}
+
+type benchResult struct {
+	NSPerOp     string
+	BPerOp      string
+	AllocsPerOp string
+}
+
+type benchRow struct {
+	Name  string
+	Label string
+}
+
+type benchTarget struct {
+	Path       string
+	MarkerName string
+	Rows       []benchRow
+}
+
+func main() {
+	if err := run(os.Args[1:]); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}
+
+func run(args []string) error {
+	fs := flag.NewFlagSet("benchsync", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+
+	root := fs.String("root", ".", "repository root")
+	inputPath := fs.String("input", "", "path to benchmark output")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if *inputPath == "" {
+		return fmt.Errorf("input benchmark file is required")
+	}
+
+	input, err := os.ReadFile(*inputPath)
+	if err != nil {
+		return fmt.Errorf("read benchmark input: %w", err)
+	}
+
+	report, err := parseBenchResults(input)
+	if err != nil {
+		return err
+	}
+
+	for _, target := range defaultTargets(*root) {
+		markdown, err := os.ReadFile(target.Path)
+		if err != nil {
+			return fmt.Errorf("read markdown %s: %w", target.Path, err)
+		}
+
+		table, err := renderBenchTable(target.Rows, report)
+		if err != nil {
+			return err
+		}
+
+		updated, err := replaceManagedBlock(markdown, target.MarkerName, table)
+		if err != nil {
+			return fmt.Errorf("update %s: %w", target.Path, err)
+		}
+
+		if err := os.WriteFile(target.Path, updated, 0o644); err != nil {
+			return fmt.Errorf("write markdown %s: %w", target.Path, err)
+		}
+	}
+
+	return nil
+}
+
+// defaultTargets enumerates the benchmark tables maintained in doc/bench.md.
+// Each row maps a Go benchmark name (with sub-benchmark path, no -GOMAXPROCS
+// suffix) to its display label. Add new rows here when adding new benchmark
+// cases to keep doc/bench.md in sync.
+func defaultTargets(root string) []benchTarget {
+	var rows []benchRow
+	for _, shape := range []struct {
+		label string
+		tag   string
+	}{
+		{"single", "single"},
+		{"loop_10", "loop_10"},
+		{"loop_100", "loop_100"},
+	} {
+		for _, ms := range []struct {
+			label string
+			tag   string
+		}{
+			{"64 B", "64B"},
+			{"1 KiB", "1KiB"},
+			{"16 KiB", "16KiB"},
+		} {
+			rows = append(rows, benchRow{
+				Name:  fmt.Sprintf("BenchmarkSend/shape=%s/messageSize=%s", shape.tag, ms.tag),
+				Label: fmt.Sprintf("Send (%s, %s)", shape.label, ms.label),
+			})
+		}
+	}
+	rows = append(rows, benchRow{
+		Name:  "BenchmarkReconnectBackoff",
+		Label: "Reconnect backoff",
+	})
+
+	return []benchTarget{
+		{
+			Path:       filepath.Join(root, "doc", "bench.md"),
+			MarkerName: "benchsync:client-go",
+			Rows:       rows,
+		},
+	}
+}
+
+func parseBenchResults(input []byte) (benchReport, error) {
+	report := benchReport{
+		Results: make(map[string]benchResult),
+	}
+
+	scanner := bufio.NewScanner(bytes.NewReader(input))
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		switch {
+		case strings.HasPrefix(line, "goos: "):
+			report.Env.GOOS = strings.TrimSpace(strings.TrimPrefix(line, "goos: "))
+			continue
+		case strings.HasPrefix(line, "goarch: "):
+			report.Env.GOARCH = strings.TrimSpace(strings.TrimPrefix(line, "goarch: "))
+			continue
+		case strings.HasPrefix(line, "cpu: "):
+			report.Env.CPU = strings.TrimSpace(strings.TrimPrefix(line, "cpu: "))
+			continue
+		}
+
+		matches := benchLinePattern.FindStringSubmatch(line)
+		if len(matches) == 0 {
+			continue
+		}
+
+		report.Results[matches[1]] = benchResult{
+			NSPerOp:     matches[2],
+			BPerOp:      matches[3],
+			AllocsPerOp: matches[4],
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return benchReport{}, fmt.Errorf("scan benchmark output: %w", err)
+	}
+	return report, nil
+}
+
+func renderBenchTable(rows []benchRow, report benchReport) (string, error) {
+	var out strings.Builder
+
+	if measurementLine := formatMeasurementLine(report.Env); measurementLine != "" {
+		out.WriteString(measurementLine)
+		out.WriteString("\n\n")
+	}
+
+	out.WriteString("| Operation | ns/op | B/op | allocs/op |\n")
+	out.WriteString("|---|---:|---:|---:|\n")
+
+	for _, row := range rows {
+		result, ok := report.Results[row.Name]
+		if !ok {
+			return "", fmt.Errorf("missing benchmark result for %s", row.Name)
+		}
+
+		if _, err := fmt.Fprintf(&out, "| `%s` | %s | %s | %s |\n",
+			row.Label,
+			formatMetric(result.NSPerOp),
+			formatMetric(result.BPerOp),
+			formatMetric(result.AllocsPerOp),
+		); err != nil {
+			return "", fmt.Errorf("render benchmark row %s: %w", row.Name, err)
+		}
+	}
+
+	return strings.TrimRight(out.String(), "\n"), nil
+}
+
+func formatMeasurementLine(env benchEnv) string {
+	platform := strings.Trim(strings.TrimSpace(env.GOOS)+"/"+strings.TrimSpace(env.GOARCH), "/")
+	switch {
+	case platform != "" && env.CPU != "":
+		return fmt.Sprintf("Measured on `%s` (`%s`).", platform, env.CPU)
+	case platform != "":
+		return fmt.Sprintf("Measured on `%s`.", platform)
+	case env.CPU != "":
+		return fmt.Sprintf("Measured on `%s`.", env.CPU)
+	default:
+		return ""
+	}
+}
+
+func replaceManagedBlock(markdown []byte, marker, content string) ([]byte, error) {
+	startMarker := "<!-- " + marker + ":start -->"
+	endMarker := "<!-- " + marker + ":end -->"
+
+	start := bytes.Index(markdown, []byte(startMarker))
+	if start == -1 {
+		return nil, fmt.Errorf("start marker not found: %s", marker)
+	}
+
+	end := bytes.Index(markdown[start:], []byte(endMarker))
+	if end == -1 {
+		return nil, fmt.Errorf("end marker not found: %s", marker)
+	}
+	end += start
+
+	var out bytes.Buffer
+	out.Write(markdown[:start+len(startMarker)])
+	out.WriteString("\n")
+	out.WriteString(content)
+	out.WriteString("\n")
+	out.Write(markdown[end:])
+	return out.Bytes(), nil
+}
+
+func formatMetric(value string) string {
+	if strings.Contains(value, ".") {
+		return strings.TrimRight(strings.TrimRight(value, "0"), ".")
+	}
+
+	n, err := strconv.ParseInt(value, 10, 64)
+	if err != nil {
+		return value
+	}
+
+	sign := ""
+	if n < 0 {
+		sign = "-"
+		n = -n
+	}
+
+	raw := strconv.FormatInt(n, 10)
+	if len(raw) <= 3 {
+		return sign + raw
+	}
+
+	var parts []string
+	for len(raw) > 3 {
+		parts = append([]string{raw[len(raw)-3:]}, parts...)
+		raw = raw[:len(raw)-3]
+	}
+	parts = append([]string{raw}, parts...)
+	return sign + strings.Join(parts, ",")
+}

--- a/cmd/benchsync/main_test.go
+++ b/cmd/benchsync/main_test.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseBenchResults_ClientGoNames(t *testing.T) {
+	t.Parallel()
+
+	input := []byte(`
+goos: darwin
+goarch: arm64
+cpu: Apple M1 Max
+BenchmarkSend/shape=single/messageSize=64B-10           1000000      3104 ns/op    1736 B/op       5 allocs/op
+BenchmarkSend/shape=loop_100/messageSize=16KiB-10           500     20000 ns/op   12000 B/op      40 allocs/op
+BenchmarkReconnectBackoff-10                          50000000       104.0 ns/op       0 B/op       0 allocs/op
+PASS
+`)
+
+	got, err := parseBenchResults(input)
+	require.NoError(t, err)
+
+	// Sub-benchmark names with slashes, equals, and underscores parse intact.
+	assert.Equal(t, "3104", got.Results["BenchmarkSend/shape=single/messageSize=64B"].NSPerOp)
+	assert.Equal(t, "20000", got.Results["BenchmarkSend/shape=loop_100/messageSize=16KiB"].NSPerOp)
+	assert.Equal(t, "104.0", got.Results["BenchmarkReconnectBackoff"].NSPerOp)
+}
+
+func TestRun(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(root, "doc"), 0o755))
+
+	benchFile := filepath.Join(root, "bench.txt")
+	require.NoError(t, os.WriteFile(benchFile, []byte(`
+goos: darwin
+goarch: arm64
+cpu: Apple M1 Max
+BenchmarkSend/shape=single/messageSize=64B-10           1000000      3104   ns/op     1736 B/op       5 allocs/op
+BenchmarkSend/shape=single/messageSize=1KiB-10           800000      4500   ns/op     2700 B/op       7 allocs/op
+BenchmarkSend/shape=single/messageSize=16KiB-10          200000     22000   ns/op    24000 B/op      11 allocs/op
+BenchmarkSend/shape=loop_10/messageSize=64B-10           300000      8500   ns/op     5400 B/op      35 allocs/op
+BenchmarkSend/shape=loop_10/messageSize=1KiB-10          250000     14000   ns/op    14000 B/op      45 allocs/op
+BenchmarkSend/shape=loop_10/messageSize=16KiB-10         100000     65000   ns/op   123000 B/op      75 allocs/op
+BenchmarkSend/shape=loop_100/messageSize=64B-10           50000     45000   ns/op    32000 B/op     310 allocs/op
+BenchmarkSend/shape=loop_100/messageSize=1KiB-10          40000     90000   ns/op    78000 B/op     410 allocs/op
+BenchmarkSend/shape=loop_100/messageSize=16KiB-10          5000    250000   ns/op   600000 B/op     710 allocs/op
+BenchmarkReconnectBackoff-10                            50000000      104.0 ns/op        0 B/op       0 allocs/op
+`), 0o644))
+
+	docPath := filepath.Join(root, "doc", "bench.md")
+	require.NoError(t, os.WriteFile(docPath, []byte(strings.TrimSpace(`
+# Benchmarks
+
+<!-- benchsync:client-go:start -->
+stale
+<!-- benchsync:client-go:end -->
+`)+"\n"), 0o644))
+
+	require.NoError(t, run([]string{"-root", root, "-input", benchFile}))
+
+	got, err := os.ReadFile(docPath)
+	require.NoError(t, err)
+	doc := string(got)
+
+	assert.Contains(t, doc, "Measured on `darwin/arm64` (`Apple M1 Max`).")
+	assert.Contains(t, doc, "| `Send (single, 64 B)` | 3,104 | 1,736 | 5 |")
+	assert.Contains(t, doc, "| `Send (loop_100, 16 KiB)` | 250,000 | 600,000 | 710 |")
+	assert.Contains(t, doc, "| `Reconnect backoff` | 104 | 0 | 0 |")
+}
+
+func TestRun_MissingResult(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(root, "doc"), 0o755))
+
+	// Bench output is missing rows the target expects.
+	benchFile := filepath.Join(root, "bench.txt")
+	require.NoError(t, os.WriteFile(benchFile, []byte(`
+BenchmarkReconnectBackoff-10  100 100 ns/op 0 B/op 0 allocs/op
+`), 0o644))
+
+	docPath := filepath.Join(root, "doc", "bench.md")
+	require.NoError(t, os.WriteFile(docPath, []byte("<!-- benchsync:client-go:start -->\n<!-- benchsync:client-go:end -->\n"), 0o644))
+
+	err := run([]string{"-root", root, "-input", benchFile})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "missing benchmark result")
+}
+
+func TestFormatMetric(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, "107", formatMetric("107.0"))
+	assert.Equal(t, "5.59", formatMetric("5.590"))
+	assert.Equal(t, "1,626", formatMetric("1626"))
+	assert.Equal(t, "3.007", formatMetric("3.007"))
+}

--- a/doc/bench.md
+++ b/doc/bench.md
@@ -1,0 +1,37 @@
+# Benchmarks
+
+Numbers below are the latest CI-published baseline for `wspulse/client-go`.
+Regenerate locally with `make bench-sync`. The CI workflow uploads the raw
+`bench.txt` output as an artefact on every PR; download it from the run page
+if you need to compare specific numbers between branches.
+
+Variance between machines is expected — these baselines are a regression
+sanity check, not a portability claim. Single runs at `-benchtime=3s -count=1`
+are noisy at the few-percent level; a one-off `bench-sync` is enough for
+order-of-magnitude regression detection but not micro-optimisation.
+
+The matrix covers:
+
+- `Send` — per-call cost across `shape ∈ {single, loop_10, loop_100}` and
+  `messageSize ∈ {64 B, 1 KiB, 16 KiB}`. `single` measures one Send per timed
+  iteration; `loop_K` measures K back-to-back Sends per iteration. Divide
+  ns/op by K to get amortised per-message cost.
+- `Reconnect backoff` — cost of one `backoff()` call. The formula must match
+  all other client-* SDKs; this is regression-bait, not a hot path.
+
+<!-- benchsync:client-go:start -->
+Measured on `darwin/arm64` (`Apple M1 Max`).
+
+| Operation | ns/op | B/op | allocs/op |
+|---|---:|---:|---:|
+| `Send (single, 64 B)` | 525.1 | 340 | 4 |
+| `Send (single, 1 KiB)` | 4,868 | 5,113 | 40 |
+| `Send (single, 16 KiB)` | 68,742 | 61,580 | 92 |
+| `Send (loop_10, 64 B)` | 5,251 | 3,480 | 48 |
+| `Send (loop_10, 1 KiB)` | 48,826 | 51,488 | 408 |
+| `Send (loop_10, 16 KiB)` | 686,637 | 615,660 | 921 |
+| `Send (loop_100, 64 B)` | 52,651 | 34,722 | 480 |
+| `Send (loop_100, 1 KiB)` | 488,082 | 513,267 | 4,068 |
+| `Send (loop_100, 16 KiB)` | 6,893,634 | 6,157,370 | 9,211 |
+| `Reconnect backoff` | 7.207 | 0 | 0 |
+<!-- benchsync:client-go:end -->

--- a/doc/bench.md
+++ b/doc/bench.md
@@ -1,9 +1,11 @@
 # Benchmarks
 
-Numbers below are the latest CI-published baseline for `wspulse/client-go`.
-Regenerate locally with `make bench-sync`. The CI workflow uploads the raw
-`bench.txt` output as an artefact on every PR; download it from the run page
-if you need to compare specific numbers between branches.
+The table below is a checked-in baseline for `wspulse/client-go`, last
+refreshed locally by a maintainer running `make bench-sync` on the hardware
+noted in the table. The CI workflow runs the same benchmarks on every PR
+and uploads the raw `bench.txt` as an artefact; download it from the run
+page if you need to compare specific numbers between branches. CI does not
+regenerate or commit this file.
 
 Variance between machines is expected — these baselines are a regression
 sanity check, not a portability claim. Single runs at `-benchtime=3s -count=1`

--- a/doc/bench.md
+++ b/doc/bench.md
@@ -26,14 +26,14 @@ Measured on `darwin/arm64` (`Apple M1 Max`).
 
 | Operation | ns/op | B/op | allocs/op |
 |---|---:|---:|---:|
-| `Send (single, 64 B)` | 525.1 | 340 | 4 |
-| `Send (single, 1 KiB)` | 4,868 | 5,113 | 40 |
-| `Send (single, 16 KiB)` | 68,742 | 61,580 | 92 |
-| `Send (loop_10, 64 B)` | 5,251 | 3,480 | 48 |
-| `Send (loop_10, 1 KiB)` | 48,826 | 51,488 | 408 |
-| `Send (loop_10, 16 KiB)` | 686,637 | 615,660 | 921 |
-| `Send (loop_100, 64 B)` | 52,651 | 34,722 | 480 |
-| `Send (loop_100, 1 KiB)` | 488,082 | 513,267 | 4,068 |
-| `Send (loop_100, 16 KiB)` | 6,893,634 | 6,157,370 | 9,211 |
-| `Reconnect backoff` | 7.207 | 0 | 0 |
+| `Send (single, 64 B)` | 577.3 | 354 | 4 |
+| `Send (single, 1 KiB)` | 4,868 | 4,975 | 39 |
+| `Send (single, 16 KiB)` | 69,404 | 61,566 | 92 |
+| `Send (loop_10, 64 B)` | 5,402 | 3,300 | 45 |
+| `Send (loop_10, 1 KiB)` | 48,818 | 50,027 | 394 |
+| `Send (loop_10, 16 KiB)` | 696,082 | 615,715 | 921 |
+| `Send (loop_100, 64 B)` | 54,600 | 33,420 | 462 |
+| `Send (loop_100, 1 KiB)` | 494,087 | 507,640 | 4,013 |
+| `Send (loop_100, 16 KiB)` | 6,918,477 | 6,157,130 | 9,211 |
+| `Reconnect backoff` | 7.824 | 0 | 0 |
 <!-- benchsync:client-go:end -->


### PR DESCRIPTION
## Summary

Release v0.10.1 — adds a checked-in benchmark harness for `client-go`. Pure dev tooling: no public API or runtime behaviour changes.

## Related issues

Closes #60

## Changes

- Add `BenchmarkSend` matrix (shape × messageSize) and `BenchmarkReconnectBackoff` in `client_bench_test.go` with a standalone WS sink handler (no `testserver` dep)
- Add `make bench-ci` and `make bench-sync` targets (portable `mktemp` template, bash scoped per-target, streamed output, failure propagation)
- Add `cmd/benchsync/` table generator that regenerates `doc/bench.md` from a fresh bench run
- Add `.github/workflows/benchmark.yml` uploading `bench.txt` as an artefact on every PR
- Check in first-iteration baseline at `doc/bench.md` (post-`b.Loop` migration)
- Migrate benches to Go 1.24 `b.Loop` pattern; gate WS sink `wg.Wait` on first-handler signal to avoid teardown races
- Promote `[Unreleased]` to `[0.10.1] - 2026-05-18` in CHANGELOG; add v0.10.0...v0.10.1 compare link

## Checklist

### Required

- [x] `make check` passes (`fmt` → `lint` → `test`)
- [x] Each commit represents exactly one logical change
- [x] Commit messages follow the format in `commit-message-instructions.md`
- [x] No unrelated code reformatting in this PR

### Conditional

- [x] Performance-sensitive change: benchmark included (this PR _is_ the benchmark harness; baseline at `doc/bench.md`)